### PR TITLE
Update the securityContext

### DIFF
--- a/deploy/1.8+/metrics-server-deployment.yaml
+++ b/deploy/1.8+/metrics-server-deployment.yaml
@@ -40,6 +40,7 @@ spec:
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+          runAsUser: 1000
         imagePullPolicy: Always
         volumeMounts:
         - name: tmp-dir


### PR DESCRIPTION
On order to avoid errors in Pod Security Policy enabled clusters, it is required to add runAsUser statement. The original one is not working with EKS  1.14