### PR TITLE
rfc: gather pod level statistics

### DIFF
--- a/pkg/sources/interfaces.go
+++ b/pkg/sources/interfaces.go
@@ -38,6 +38,10 @@ type PodMetricsPoint struct {
 	Name      string
 	Namespace string
 
+	// Stats pertaining to CPU and memory (RAM) resources consumed by pod cgroup (which includes all containers' resource usage and pod overhead).
+	// +optional
+	PodMetric ContainerMetricsPoint
+
 	Containers []ContainerMetricsPoint
 }
 


### PR DESCRIPTION
Hey ya'll --

The Kubelet exposes resource utilizing at both the pod and container
granularity.  Currently metrics server only gathers the container
stats. Measured pod usage doesn't always equal the sum of containers'
usage, as there are often non-negligible overheads associated with
running a pod. 

In particular, pod stats from kubelet are grabbed from the pod cgroup, whereas containers are from each individual containers cgroup (for runc based containers, these would be a direct child of the pod cgroup, their parent).  Aside from the other containers, there could be other processes running within this pod cgroup: containerd/crio shims, VMMs in case of sandboxed runtimes, etc.  Even in common configurations, there can be a delta between what is utilized by the pod, versus the sum of containers.

This PR updates metrics' server to also take pod measured usage into account. This helps on the 'source side', but there'd need to be similar changes on the storage side, as well as with the metrics API as well.  

Signed-off-by: Eric Ernst <eric.ernst@intel.com>