### PR TITLE
Add nodeSelector to deploy only on Linux.

### DIFF
--- a/deploy/1.8+/metrics-server-deployment.yaml
+++ b/deploy/1.8+/metrics-server-deployment.yaml
@@ -45,4 +45,5 @@ spec:
         volumeMounts:
         - name: tmp-dir
           mountPath: /tmp
-
+      nodeSelector:
+        beta.kubernetes.io/os: linux


### PR DESCRIPTION
Simple fix for issue #357. 

Added `nodeSelector` label to constrain metrics-server deployments to Linux.