### PR TITLE
report memory from RSSBytes instead of WorkingSetBytes

### DIFF
--- a/pkg/sources/summary/summary.go
+++ b/pkg/sources/summary/summary.go
@@ -202,11 +202,11 @@ func decodeCPU(target *resource.Quantity, cpuStats *stats.CPUStats) error {
 }
 
 func decodeMemory(target *resource.Quantity, memStats *stats.MemoryStats) error {
-	if memStats == nil || memStats.WorkingSetBytes == nil {
+	if memStats == nil || memStats.UsageBytes == nil {
 		return fmt.Errorf("missing memory usage metric")
 	}
 
-	*target = *uint64Quantity(*memStats.WorkingSetBytes, 0)
+	*target = *uint64Quantity(*memStats.UsageBytes, 0)
 	target.Format = resource.BinarySI
 
 	return nil

--- a/pkg/sources/summary/summary.go
+++ b/pkg/sources/summary/summary.go
@@ -202,11 +202,11 @@ func decodeCPU(target *resource.Quantity, cpuStats *stats.CPUStats) error {
 }
 
 func decodeMemory(target *resource.Quantity, memStats *stats.MemoryStats) error {
-	if memStats == nil || memStats.UsageBytes == nil {
+	if memStats == nil || memStats.RSSBytes == nil {
 		return fmt.Errorf("missing memory usage metric")
 	}
 
-	*target = *uint64Quantity(*memStats.UsageBytes, 0)
+	*target = *uint64Quantity(*memStats.RSSBytes, 0)
 	target.Format = resource.BinarySI
 
 	return nil

--- a/pkg/sources/summary/summary_test.go
+++ b/pkg/sources/summary/summary_test.go
@@ -65,10 +65,10 @@ func cpuStats(usageNanocores uint64, ts time.Time) *stats.CPUStats {
 	}
 }
 
-func memStats(usageBytes uint64, ts time.Time) *stats.MemoryStats {
+func memStats(rssBytes uint64, ts time.Time) *stats.MemoryStats {
 	return &stats.MemoryStats{
-		Time:       metav1.Time{ts},
-		UsageBytes: &usageBytes,
+		Time:     metav1.Time{ts},
+		RSSBytes: &rssBytes,
 	}
 }
 
@@ -100,8 +100,8 @@ func verifyNode(nodeName string, summary *stats.Summary, batch *sources.MetricsB
 		timestamp = summary.Node.CPU.Time.Time
 	}
 	if summary.Node.Memory != nil {
-		if summary.Node.Memory.UsageBytes != nil {
-			memoryUsage = *resource.NewQuantity(int64(*summary.Node.Memory.UsageBytes), resource.BinarySI)
+		if summary.Node.Memory.RSSBytes != nil {
+			memoryUsage = *resource.NewQuantity(int64(*summary.Node.Memory.RSSBytes), resource.BinarySI)
 		}
 		if timestamp.IsZero() {
 			timestamp = summary.Node.Memory.Time.Time
@@ -134,11 +134,11 @@ func verifyPods(summary *stats.Summary, batch *sources.MetricsBatch) {
 			}
 			cpuUsage = *resource.NewScaledQuantity(int64(*container.CPU.UsageNanoCores), -9)
 			timestamp = container.CPU.Time.Time
-			if container.Memory == nil || container.Memory.UsageBytes == nil {
+			if container.Memory == nil || container.Memory.RSSBytes == nil {
 				missingData = true
 				break
 			}
-			memoryUsage = *resource.NewQuantity(int64(*container.Memory.UsageBytes), resource.BinarySI)
+			memoryUsage = *resource.NewQuantity(int64(*container.Memory.RSSBytes), resource.BinarySI)
 			if timestamp.IsZero() {
 				timestamp = container.Memory.Time.Time
 			}
@@ -254,7 +254,7 @@ var _ = Describe("Summary Source", func() {
 		client.metrics.Pods[0].Containers[1].CPU = nil
 		client.metrics.Pods[1].Containers[0].CPU.UsageNanoCores = nil
 		client.metrics.Pods[2].Containers[0].Memory = nil
-		client.metrics.Pods[3].Containers[0].Memory.UsageBytes = nil
+		client.metrics.Pods[3].Containers[0].Memory.RSSBytes = nil
 
 		By("collecting the batch")
 		batch, err := src.Collect(context.Background())
@@ -272,10 +272,10 @@ var _ = Describe("Summary Source", func() {
 		minusTen := uint64(math.MaxUint64 - 10)
 		minusOneHundred := uint64(math.MaxUint64 - 100)
 
-		client.metrics.Node.Memory.UsageBytes = &plusTen     // RAM is cheap, right?
+		client.metrics.Node.Memory.RSSBytes = &plusTen       // RAM is cheap, right?
 		client.metrics.Node.CPU.UsageNanoCores = &plusTwenty // a mainframe, probably
 		client.metrics.Pods[0].Containers[1].CPU.UsageNanoCores = &minusTen
-		client.metrics.Pods[1].Containers[0].Memory.UsageBytes = &minusOneHundred
+		client.metrics.Pods[1].Containers[0].Memory.RSSBytes = &minusOneHundred
 
 		By("collecting the batch")
 		batch, err := src.Collect(context.Background())


### PR DESCRIPTION
more discussion in #187, but basically:

* WorkingSetBytes reports "recently-used" memory. This excludes memory that Linux thinks is swappable, i.e., memory that hasn't been read/written in a while.
* Kubernetes does not "support" swap (e.g., for memory limits and other things), so we should treat the entire memory image as "memory used"
* WorkingSetBytes therefore always reports <= memory image size, sometimes (in pretty reasonable/frequent circumstances) by a lot less (e.g., for workloads that load a lot of data into memory but don't continually reference all of it)
* RSSBytes reports memory image size minus shmem size, so it still under-counts, but `shmem` is usually small and fixed (and counting both might overcount, since shmem might get counted by multiple containers). So, though it may still under-count, it should under-count by significantly less.