### PR TITLE
Migrate repository path to sigs.k8s.io/metrics-server

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,4 +14,4 @@ linters:
 
 linters-settings:
   goimports:
-local-prefixes: github.com/kubernetes-incubator/metrics-server
+local-prefixes: sigs.k8s.io/metrics-server

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ include hack/Makefile.buildinfo
 # but it allows us to safely write actual dependency rules in our makefile)
 src_deps=$(shell find pkg cmd -type f -name "*.go")
 _output/%/metrics-server: $(src_deps)	
-	GO111MODULE=on GOARCH=$* CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o _output/$*/metrics-server github.com/kubernetes-incubator/metrics-server/cmd/metrics-server
+	GO111MODULE=on GOARCH=$* CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o _output/$*/metrics-server sigs.k8s.io/metrics-server/cmd/metrics-server
 
 # Image Rules
 # -----------

--- a/cmd/metrics-server/app/start.go
+++ b/cmd/metrics-server/app/start.go
@@ -31,13 +31,13 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/kubernetes-incubator/metrics-server/pkg/apiserver"
-	genericmetrics "github.com/kubernetes-incubator/metrics-server/pkg/apiserver/generic"
-	"github.com/kubernetes-incubator/metrics-server/pkg/manager"
-	"github.com/kubernetes-incubator/metrics-server/pkg/provider/sink"
-	"github.com/kubernetes-incubator/metrics-server/pkg/sources"
-	"github.com/kubernetes-incubator/metrics-server/pkg/sources/summary"
-	"github.com/kubernetes-incubator/metrics-server/pkg/version"
+	"sigs.k8s.io/metrics-server/pkg/apiserver"
+	genericmetrics "sigs.k8s.io/metrics-server/pkg/apiserver/generic"
+	"sigs.k8s.io/metrics-server/pkg/manager"
+	"sigs.k8s.io/metrics-server/pkg/provider/sink"
+	"sigs.k8s.io/metrics-server/pkg/sources"
+	"sigs.k8s.io/metrics-server/pkg/sources/summary"
+	"sigs.k8s.io/metrics-server/pkg/version"
 )
 
 // NewCommandStartMetricsServer provides a CLI handler for the metrics server entrypoint

--- a/cmd/metrics-server/metrics-server.go
+++ b/cmd/metrics-server/metrics-server.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/component-base/logs"
 
-	"github.com/kubernetes-incubator/metrics-server/cmd/metrics-server/app"
+	"sigs.k8s.io/metrics-server/cmd/metrics-server/app"
 )
 
 func main() {

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -3,7 +3,7 @@ ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 ENV GOPATH=/go
 
-WORKDIR /go/src/github.com/kubernetes-incubator/metrics-server
+WORKDIR /go/src/sigs.k8s.io/metrics-server
 COPY go.mod .
 COPY go.sum .
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kubernetes-incubator/metrics-server
+module sigs.k8s.io/metrics-server
 
 go 1.12
 

--- a/hack/calc-build-info.sh
+++ b/hack/calc-build-info.sh
@@ -77,7 +77,7 @@ build-date() {
 
 # version-ldflags returns the appropriate ldflags for building metrics-server
 version-ldflags() {
-    local package="github.com/kubernetes-incubator/metrics-server/pkg/version"
+    local package="sigs.k8s.io/metrics-server/pkg/version"
     echo "-X ${package}.gitVersion=$(version-string) -X ${package}.gitCommit=$(git-commit) -X ${package}.gitTreeState=$(git-tree-state) -X ${package}.buildDate=$(build-date)"
 }
 

--- a/pkg/apiserver/config.go
+++ b/pkg/apiserver/config.go
@@ -21,9 +21,9 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/informers"
 
-	"github.com/kubernetes-incubator/metrics-server/pkg/apiserver/generic"
-	generatedopenapi "github.com/kubernetes-incubator/metrics-server/pkg/generated/openapi"
-	"github.com/kubernetes-incubator/metrics-server/pkg/version"
+	"sigs.k8s.io/metrics-server/pkg/apiserver/generic"
+	generatedopenapi "sigs.k8s.io/metrics-server/pkg/generated/openapi"
+	"sigs.k8s.io/metrics-server/pkg/version"
 )
 
 // Config contains configuration for launching an instance of metrics-server.

--- a/pkg/apiserver/generic/storage.go
+++ b/pkg/apiserver/generic/storage.go
@@ -26,9 +26,9 @@ import (
 	"k8s.io/metrics/pkg/apis/metrics/install"
 	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
 
-	"github.com/kubernetes-incubator/metrics-server/pkg/provider"
-	nodemetricsstorage "github.com/kubernetes-incubator/metrics-server/pkg/storage/nodemetrics"
-	podmetricsstorage "github.com/kubernetes-incubator/metrics-server/pkg/storage/podmetrics"
+	"sigs.k8s.io/metrics-server/pkg/provider"
+	nodemetricsstorage "sigs.k8s.io/metrics-server/pkg/storage/nodemetrics"
+	podmetricsstorage "sigs.k8s.io/metrics-server/pkg/storage/podmetrics"
 )
 
 var (

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -21,10 +21,11 @@ import (
 	"sync"
 	"time"
 
-	utilmetrics "github.com/kubernetes-incubator/metrics-server/pkg/metrics"
-	"github.com/kubernetes-incubator/metrics-server/pkg/sink"
-	"github.com/kubernetes-incubator/metrics-server/pkg/sources"
 	"k8s.io/klog"
+
+	utilmetrics "sigs.k8s.io/metrics-server/pkg/metrics"
+	"sigs.k8s.io/metrics-server/pkg/sink"
+	"sigs.k8s.io/metrics-server/pkg/sources"
 
 	"github.com/prometheus/client_golang/prometheus"
 )

--- a/pkg/metrics/util_test.go
+++ b/pkg/metrics/util_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
 
-	. "github.com/kubernetes-incubator/metrics-server/pkg/metrics"
+	. "sigs.k8s.io/metrics-server/pkg/metrics"
 )
 
 func TestMetricsUtil(t *testing.T) {

--- a/pkg/provider/sink/sinkprov.go
+++ b/pkg/provider/sink/sinkprov.go
@@ -20,12 +20,12 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
 	"k8s.io/metrics/pkg/apis/metrics"
 
-	"github.com/kubernetes-incubator/metrics-server/pkg/provider"
-	"github.com/kubernetes-incubator/metrics-server/pkg/sink"
-	"github.com/kubernetes-incubator/metrics-server/pkg/sources"
-	"k8s.io/klog"
+	"sigs.k8s.io/metrics-server/pkg/provider"
+	"sigs.k8s.io/metrics-server/pkg/sink"
+	"sigs.k8s.io/metrics-server/pkg/sources"
 )
 
 // kubernetesCadvisorWindow is the max window used by cAdvisor for calculating

--- a/pkg/provider/sink/sinkprov_test.go
+++ b/pkg/provider/sink/sinkprov_test.go
@@ -25,10 +25,10 @@ import (
 	apitypes "k8s.io/apimachinery/pkg/types"
 	metrics "k8s.io/metrics/pkg/apis/metrics"
 
-	"github.com/kubernetes-incubator/metrics-server/pkg/provider"
-	. "github.com/kubernetes-incubator/metrics-server/pkg/provider/sink"
-	"github.com/kubernetes-incubator/metrics-server/pkg/sink"
-	"github.com/kubernetes-incubator/metrics-server/pkg/sources"
+	"sigs.k8s.io/metrics-server/pkg/provider"
+	. "sigs.k8s.io/metrics-server/pkg/provider/sink"
+	"sigs.k8s.io/metrics-server/pkg/sink"
+	"sigs.k8s.io/metrics-server/pkg/sources"
 )
 
 var defaultWindow = 30 * time.Second

--- a/pkg/sink/interfaces.go
+++ b/pkg/sink/interfaces.go
@@ -15,7 +15,7 @@
 package sink
 
 import (
-	"github.com/kubernetes-incubator/metrics-server/pkg/sources"
+	"sigs.k8s.io/metrics-server/pkg/sources"
 )
 
 // MetricSink knows how to receive metrics batches from a source.

--- a/pkg/sources/fake/fakes.go
+++ b/pkg/sources/fake/fakes.go
@@ -17,7 +17,7 @@ package fake
 import (
 	"context"
 
-	"github.com/kubernetes-incubator/metrics-server/pkg/sources"
+	"sigs.k8s.io/metrics-server/pkg/sources"
 )
 
 // StaticSourceProvider is a fake sources.MetricSourceProvider that returns

--- a/pkg/sources/manager.go
+++ b/pkg/sources/manager.go
@@ -24,7 +24,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog"
 
-	utilmetrics "github.com/kubernetes-incubator/metrics-server/pkg/metrics"
+	utilmetrics "sigs.k8s.io/metrics-server/pkg/metrics"
 )
 
 const (

--- a/pkg/sources/manager_test.go
+++ b/pkg/sources/manager_test.go
@@ -24,8 +24,8 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	. "github.com/kubernetes-incubator/metrics-server/pkg/sources"
-	fakesrc "github.com/kubernetes-incubator/metrics-server/pkg/sources/fake"
+	. "sigs.k8s.io/metrics-server/pkg/sources"
+	fakesrc "sigs.k8s.io/metrics-server/pkg/sources/fake"
 )
 
 const timeDrift = 50 * time.Millisecond

--- a/pkg/sources/summary/summary.go
+++ b/pkg/sources/summary/summary.go
@@ -20,8 +20,6 @@ import (
 	"math"
 	"time"
 
-	"github.com/kubernetes-incubator/metrics-server/pkg/sources"
-	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
@@ -29,6 +27,10 @@ import (
 	v1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog"
 	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
+
+	"sigs.k8s.io/metrics-server/pkg/sources"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (

--- a/pkg/sources/summary/summary_test.go
+++ b/pkg/sources/summary/summary_test.go
@@ -30,8 +30,8 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
 
-	"github.com/kubernetes-incubator/metrics-server/pkg/sources"
-	. "github.com/kubernetes-incubator/metrics-server/pkg/sources/summary"
+	"sigs.k8s.io/metrics-server/pkg/sources"
+	. "sigs.k8s.io/metrics-server/pkg/sources/summary"
 )
 
 func TestSummarySource(t *testing.T) {

--- a/pkg/storage/nodemetrics/reststorage.go
+++ b/pkg/storage/nodemetrics/reststorage.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kubernetes-incubator/metrics-server/pkg/provider"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -34,6 +33,7 @@ import (
 	"k8s.io/klog"
 	"k8s.io/metrics/pkg/apis/metrics"
 	_ "k8s.io/metrics/pkg/apis/metrics/install"
+	"sigs.k8s.io/metrics-server/pkg/provider"
 )
 
 type MetricStorage struct {

--- a/pkg/storage/nodemetrics/reststorage_test.go
+++ b/pkg/storage/nodemetrics/reststorage_test.go
@@ -27,11 +27,11 @@ import (
 	labels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/diff"
 
-	"github.com/kubernetes-incubator/metrics-server/pkg/provider"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	clientv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/metrics/pkg/apis/metrics"
+	"sigs.k8s.io/metrics-server/pkg/provider"
 )
 
 // fakes both PodLister and PodNamespaceLister at once

--- a/pkg/storage/podmetrics/reststorage.go
+++ b/pkg/storage/podmetrics/reststorage.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kubernetes-incubator/metrics-server/pkg/provider"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -36,6 +35,7 @@ import (
 	"k8s.io/klog"
 	"k8s.io/metrics/pkg/apis/metrics"
 	_ "k8s.io/metrics/pkg/apis/metrics/install"
+	"sigs.k8s.io/metrics-server/pkg/provider"
 )
 
 type MetricStorage struct {

--- a/pkg/storage/podmetrics/reststorage_test.go
+++ b/pkg/storage/podmetrics/reststorage_test.go
@@ -25,13 +25,13 @@ import (
 	fields "k8s.io/apimachinery/pkg/fields"
 	labels "k8s.io/apimachinery/pkg/labels"
 
-	"github.com/kubernetes-incubator/metrics-server/pkg/provider"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/diff"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	listerv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/metrics/pkg/apis/metrics"
+	"sigs.k8s.io/metrics-server/pkg/provider"
 )
 
 // fakes both PodLister and PodNamespaceLister at once


### PR DESCRIPTION
MetricsServer repo was migrated to KubernetesSIGs org and now is
available on this address.