### PR TITLE
Updated decodeMemory in summary to use working set size, not RSS

### DIFF
--- a/pkg/sources/summary/summary.go
+++ b/pkg/sources/summary/summary.go
@@ -204,11 +204,11 @@ func decodeCPU(target *resource.Quantity, cpuStats *stats.CPUStats) error {
 }
 
 func decodeMemory(target *resource.Quantity, memStats *stats.MemoryStats) error {
-	if memStats == nil || memStats.RSSBytes == nil {
+	if memStats == nil || memStats.WorkingSetBytes == nil {
 		return fmt.Errorf("missing memory usage metric")
 	}
 
-	*target = *uint64Quantity(*memStats.RSSBytes, 0)
+	*target = *uint64Quantity(*memStats.WorkingSetBytes, 0)
 	target.Format = resource.BinarySI
 
 	return nil

--- a/pkg/sources/summary/summary_test.go
+++ b/pkg/sources/summary/summary_test.go
@@ -65,10 +65,10 @@ func cpuStats(usageNanocores uint64, ts time.Time) *stats.CPUStats {
 	}
 }
 
-func memStats(rssBytes uint64, ts time.Time) *stats.MemoryStats {
+func memStats(workingSetBytes uint64, ts time.Time) *stats.MemoryStats {
 	return &stats.MemoryStats{
-		Time:     metav1.Time{ts},
-		RSSBytes: &rssBytes,
+		Time:            metav1.Time{ts},
+		WorkingSetBytes: &workingSetBytes,
 	}
 }
 
@@ -100,8 +100,8 @@ func verifyNode(nodeName string, summary *stats.Summary, batch *sources.MetricsB
 		timestamp = summary.Node.CPU.Time.Time
 	}
 	if summary.Node.Memory != nil {
-		if summary.Node.Memory.RSSBytes != nil {
-			memoryUsage = *resource.NewQuantity(int64(*summary.Node.Memory.RSSBytes), resource.BinarySI)
+		if summary.Node.Memory.WorkingSetBytes != nil {
+			memoryUsage = *resource.NewQuantity(int64(*summary.Node.Memory.WorkingSetBytes), resource.BinarySI)
 		}
 		if timestamp.IsZero() {
 			timestamp = summary.Node.Memory.Time.Time
@@ -134,11 +134,11 @@ func verifyPods(summary *stats.Summary, batch *sources.MetricsBatch) {
 			}
 			cpuUsage = *resource.NewScaledQuantity(int64(*container.CPU.UsageNanoCores), -9)
 			timestamp = container.CPU.Time.Time
-			if container.Memory == nil || container.Memory.RSSBytes == nil {
+			if container.Memory == nil || container.Memory.WorkingSetBytes == nil {
 				missingData = true
 				break
 			}
-			memoryUsage = *resource.NewQuantity(int64(*container.Memory.RSSBytes), resource.BinarySI)
+			memoryUsage = *resource.NewQuantity(int64(*container.Memory.WorkingSetBytes), resource.BinarySI)
 			if timestamp.IsZero() {
 				timestamp = container.Memory.Time.Time
 			}
@@ -254,7 +254,7 @@ var _ = Describe("Summary Source", func() {
 		client.metrics.Pods[0].Containers[1].CPU = nil
 		client.metrics.Pods[1].Containers[0].CPU.UsageNanoCores = nil
 		client.metrics.Pods[2].Containers[0].Memory = nil
-		client.metrics.Pods[3].Containers[0].Memory.RSSBytes = nil
+		client.metrics.Pods[3].Containers[0].Memory.WorkingSetBytes = nil
 
 		By("collecting the batch")
 		batch, err := src.Collect(context.Background())
@@ -272,10 +272,10 @@ var _ = Describe("Summary Source", func() {
 		minusTen := uint64(math.MaxUint64 - 10)
 		minusOneHundred := uint64(math.MaxUint64 - 100)
 
-		client.metrics.Node.Memory.RSSBytes = &plusTen       // RAM is cheap, right?
-		client.metrics.Node.CPU.UsageNanoCores = &plusTwenty // a mainframe, probably
+		client.metrics.Node.Memory.WorkingSetBytes = &plusTen // RAM is cheap, right?
+		client.metrics.Node.CPU.UsageNanoCores = &plusTwenty  // a mainframe, probably
 		client.metrics.Pods[0].Containers[1].CPU.UsageNanoCores = &minusTen
-		client.metrics.Pods[1].Containers[0].Memory.RSSBytes = &minusOneHundred
+		client.metrics.Pods[1].Containers[0].Memory.WorkingSetBytes = &minusOneHundred
 
 		By("collecting the batch")
 		batch, err := src.Collect(context.Background())


### PR DESCRIPTION
The metrics API defines memory usage for NodeMetrics and ContainerMetrics as the memory working set ([link](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/resource-metrics-api.md#schema)), but `decodeMemory` previously returned the resident set size when computing summary statistics. This commit updates `decodeMemory` so that it returns `memStats.WorkingSetBytes` instead of `memStats.RSSBytes`, bringing memory statistics in line with the metrics API.

Tests are also updated to reflect this change.