### PR TITLE
Adds Readiness check to metrics-server

### DIFF
--- a/cmd/metrics-server/app/start.go
+++ b/cmd/metrics-server/app/start.go
@@ -220,6 +220,9 @@ func (o MetricsServerOptions) Run(stopCh <-chan struct{}) error {
 	config.ProviderConfig.Node = metricsProvider
 	config.ProviderConfig.Pod = metricsProvider
 
+	// Add our Ready check to GenericConfig
+	config.GenericConfig.ReadyzChecks = []healthz.HealthChecker{healthz.NamedCheck("readyz", mgr.IsReady)}
+
 	// complete the config to get an API server
 	server, err := config.Complete(informerFactory).New()
 	if err != nil {


### PR DESCRIPTION
This is my initial take at adding a readiness check. I am open to feedback on how to better improve it. `CheckHealth`  is currently using `AddHealthChecks` which also adds it as a readiness check. So, there is more than one readiness check. 

This is to address https://github.com/kubernetes-sigs/metrics-server/issues/291