### PR TITLE
Add amd64 to the nodeSelector

### DIFF
--- a/deploy/1.8+/metrics-server-deployment.yaml
+++ b/deploy/1.8+/metrics-server-deployment.yaml
@@ -47,3 +47,4 @@ spec:
           mountPath: /tmp
       nodeSelector:
         beta.kubernetes.io/os: linux
+        kubernetes.io/arch: "amd64"


### PR DESCRIPTION
When running in a multi-arch cluster, this keeps it on nodes that it can run on