### PR TITLE
[WIP] Setup watch with filter selector for running pods

### DIFF
--- a/pkg/api/pod_test.go
+++ b/pkg/api/pod_test.go
@@ -69,7 +69,7 @@ func (mp fakePodMetricsGetter) GetContainerMetrics(pods ...apitypes.NamespacedNa
 
 func NewPodTestStorage(resp interface{}, err error) *podMetrics {
 	return &podMetrics{
-		podLister: fakePodLister{
+		runningPodsLister: fakePodLister{
 			resp: resp,
 			err:  err,
 		},
@@ -171,29 +171,6 @@ func TestPodList_WithFieldSelectors(t *testing.T) {
 	res := got.(*metrics.PodMetricsList)
 
 	if len(res.Items) != 1 || res.Items[0].Containers[0].Name != "metric1" {
-		t.Errorf("Got unexpected object: %+v", got)
-	}
-}
-
-func TestPodList_PodNotRunning(t *testing.T) {
-	// setup
-	pods := createTestPods()
-	pods[1].Status.Phase = v1.PodPending
-
-	r := NewPodTestStorage(pods, nil)
-
-	// execute
-	got, err := r.List(genericapirequest.NewContext(), nil)
-
-	// assert
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	res := got.(*metrics.PodMetricsList)
-
-	if len(res.Items) != 2 ||
-		res.Items[0].Name != "pod1" ||
-		res.Items[1].Name != "pod3" {
 		t.Errorf("Got unexpected object: %+v", got)
 	}
 }


### PR DESCRIPTION
It will reduce resource requirements for clusters with lot of terminated
pods. Will change semantic of Get, by returning pod not found for non
running pods.

Fixes https://github.com/kubernetes-sigs/metrics-server/issues/394

