### PR TITLE
Add cloudbuild.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Common User-Settable Flags
 # ==========================
 # Push to staging registry.
-PREFIX?=staging-k8s.gcr.io
+PREFIX?=gcr.io/k8s-staging-metrics-server
 FLAGS=
 ARCH?=amd64
 GOLANG_VERSION?=1.13.8

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,9 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 1200s
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4'
+    entrypoint: make
+    args:
+    - push


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds cloudbuild.yaml file needed for automated build pipeline

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Ref https://github.com/kubernetes-sigs/metrics-server/issues/365

/cc @s-urbaniak 

Tested by:
```
gcloud components install cloud-build-local
cloud-build-local --config=cloudbuild.yaml --dryrun=false --push .
```