### PR TITLE
Maintain the same ordering invariant that the Kube API server does

### DIFF
--- a/pkg/api/node.go
+++ b/pkg/api/node.go
@@ -17,6 +17,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -97,6 +98,8 @@ func (m *nodeMetrics) List(ctx context.Context, options *metainternalversion.Lis
 	for i, node := range nodes {
 		names[i] = node.Name
 	}
+	// maintain the same ordering invariant as the Kube API would over nodes
+	sort.Strings(names)
 
 	metricsItems, err := m.getNodeMetrics(names...)
 	if err != nil {

--- a/pkg/api/pod.go
+++ b/pkg/api/pod.go
@@ -17,6 +17,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -95,6 +96,14 @@ func (m *podMetrics) List(ctx context.Context, options *metainternalversion.List
 			}
 		}
 	}
+
+	// maintain the same ordering invariant as the Kube API would over pods
+	sort.Slice(pods, func(i, j int) bool {
+		if pods[i].Namespace != pods[j].Namespace {
+			return pods[i].Namespace < pods[j].Namespace
+		}
+		return pods[i].Name < pods[j].Name
+	})
 
 	metricsItems, err := m.getPodMetrics(pods...)
 	if err != nil {

--- a/pkg/api/pod.go
+++ b/pkg/api/pod.go
@@ -89,12 +89,19 @@ func (m *podMetrics) List(ctx context.Context, options *metainternalversion.List
 
 	// currently the PodLister API does not support filtering using FieldSelectors, we have to filter manually
 	if options != nil && options.FieldSelector != nil {
-		for i := len(pods) - 1; i >= 0; i-- {
-			fieldsSet := generic.AddObjectMetaFieldsSet(make(fields.Set, 2), &pods[i].ObjectMeta, true)
-			if !options.FieldSelector.Matches(fieldsSet) {
-				pods = append(pods[:i], pods[i+1:]...)
+		newPods := make([]*v1.Pod, 0, len(pods))
+		fields := make(fields.Set, 2)
+		for _, pod := range pods {
+			for k := range fields {
+				delete(fields, k)
 			}
+			fieldsSet := generic.AddObjectMetaFieldsSet(fields, &pod.ObjectMeta, true)
+			if !options.FieldSelector.Matches(fieldsSet) {
+				continue
+			}
+			newPods = append(newPods, pod)
 		}
+		pods = newPods
 	}
 
 	// maintain the same ordering invariant as the Kube API would over pods

--- a/pkg/api/pod_test.go
+++ b/pkg/api/pod_test.go
@@ -153,8 +153,8 @@ func TestPodList_PodNotRunning(t *testing.T) {
 	res := got.(*metrics.PodMetricsList)
 
 	if len(res.Items) != 2 ||
-		res.Items[0].Containers[0].Name != "metric1" ||
-		res.Items[1].Containers[0].Name != "metric3" {
+		res.Items[0].Name != "pod1" ||
+		res.Items[1].Name != "pod3" {
 		t.Errorf("Got unexpected object: %+v", got)
 	}
 }
@@ -162,12 +162,15 @@ func TestPodList_PodNotRunning(t *testing.T) {
 func createTestPods() []*v1.Pod {
 	pod1 := &v1.Pod{}
 	pod1.Namespace = "other"
+	pod1.Name = "pod1"
 	pod1.Status.Phase = v1.PodRunning
 	pod2 := &v1.Pod{}
 	pod2.Namespace = "testValue"
+	pod2.Name = "pod2"
 	pod2.Status.Phase = v1.PodRunning
 	pod3 := &v1.Pod{}
 	pod3.Namespace = "other"
+	pod3.Name = "pod3"
 	pod3.Status.Phase = v1.PodRunning
 	return []*v1.Pod{pod1, pod2, pod3}
 }


### PR DESCRIPTION
For consistency with the rest of the API ecosystem, we should have
a consistent default order with the upstream APIs for nodes and
pods. The cost is relatively small for nodes and for viewing all
pods should be less expensive than populating the pod list with
metrics for all pods.


@liggitt since we don't formally specify this, but is kind of implicit (i think we should make it explicit in the rules for kube apis)