### PR TITLE
Update RELEASE.md to use image build pipeline and manifests as part of release

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,10 @@ Metrics Server | Metrics API group/version | Supported Kubernetes version
 0.2.x          | `metrics.k8s.io/v1beta1`  | 1.8+
 
 
-In order to deploy metrics-server in your cluster run the following command from
-the top-level directory of this repository:
+In order to deploy metrics-server in your cluster run the following command:
 
 ```console
-$ kubectl apply -f deploy/kubernetes/
+$ kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.6/components.yaml
 ```
 
 You can also use this helm chart to deploy the metric-server in your cluster (This isn't supported by the metrics-server maintainers): https://github.com/helm/charts/tree/master/stable/metrics-server

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,11 @@ The Metrics Server is released on an as-needed basis. The process is as follows:
 
 1. An issue is proposing a new release with a changelog since the last release
 1. At least one [OWNER](OWNERS) must LGTM this release
-1. An OWNER runs `git tag -s $VERSION` and inserts the changelog and pushes the tag with `git push $VERSION`
-1. An OWNER pushes docker images into all officially supported image registries
-1. The release issue is closed
+1. A PR that bumps version hardcoded in code is created and merged
+1. An OWNER creates a draft GitHub release
+1. An OWNER creates a release tag using `GIT_TAG=$VERSION make release-tag` and waits for [prow.k8s.io](prow.k8s.io) to build and push new images to [gcr.io/k8s-staging-metrics-server](https://gcr.io/k8s-staging-metrics-server)
+1. An OWNER builds the release manifests using `make release-manifests` and uploads them to Github release
+1. A PR in [kubernetes/k8s.io](https://github.com/kubernetes/k8s.io/blob/master/k8s.gcr.io/images/k8s-staging-metrics-server/images.yaml) is created to release images to `k8s.gcr.io`
+1. An OWNER publishes the GitHub release
 1. An announcement email is sent to `kubernetes-sig-instrumentation@googlegroups.com` with the subject `[ANNOUNCE] metrics-server $VERSION is released`
+1. The release issue is closed

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -23,7 +23,7 @@ setup_kind() {
 }
 
 deploy(){
-  kubectl apply -f deploy/kubernetes/
+  kubectl apply -f _output/components.yaml
   # Apply patch to use provided image
   kubectl -n kube-system patch deployment metrics-server --patch "{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"metrics-server\", \"image\": \"${IMAGE}\", \"imagePullPolicy\": \"Never\"}]}}}}"
   # Configure metrics-server preffered address to InternalIP for it to work with KinD


### PR DESCRIPTION
Refs https://github.com/kubernetes-sigs/metrics-server/issues/471 
Fixes https://github.com/kubernetes-sigs/metrics-server/issues/365
/cc @s-urbaniak 

