### PR TITLE
Backport v0.3.6 manifests from origin/master

### DIFF
--- a/deploy/1.8+/aggregated-metrics-reader.yaml
+++ b/deploy/1.8+/aggregated-metrics-reader.yaml
@@ -1,5 +1,6 @@
-kind: ClusterRole
+---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
   name: system:aggregated-metrics-reader
   labels:

--- a/deploy/1.8+/auth-delegator.yaml
+++ b/deploy/1.8+/auth-delegator.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: metrics-server:system:auth-delegator

--- a/deploy/1.8+/auth-reader.yaml
+++ b/deploy/1.8+/auth-reader.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-server-auth-reader

--- a/deploy/1.8+/metrics-server-deployment.yaml
+++ b/deploy/1.8+/metrics-server-deployment.yaml
@@ -30,8 +30,21 @@ spec:
       containers:
       - name: metrics-server
         image: k8s.gcr.io/metrics-server-amd64:v0.3.6
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
+        args:
+          - --cert-dir=/tmp
+          - --secure-port=4443
+        ports:
+        - name: main-port
+          containerPort: 4443
+          protocol: TCP
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         volumeMounts:
         - name: tmp-dir
           mountPath: /tmp
-
+      nodeSelector:
+        kubernetes.io/os: linux
+        kubernetes.io/arch: "amd64"

--- a/deploy/1.8+/metrics-server-service.yaml
+++ b/deploy/1.8+/metrics-server-service.yaml
@@ -13,4 +13,4 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: main-port

--- a/deploy/1.8+/resource-reader.yaml
+++ b/deploy/1.8+/resource-reader.yaml
@@ -11,6 +11,7 @@ rules:
   - nodes
   - nodes/stats
   - namespaces
+  - configmaps
   verbs:
   - get
   - list


### PR DESCRIPTION
This is needed to treat manfiests as part of release.
Before v0.3.6 manfiests were updated on origin/master, by backporting we
will avoid downgrade.

Refs https://github.com/kubernetes-sigs/metrics-server/issues/471
/cc @s-urbaniak 
