### PR TITLE
Fix multi-arch image push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ BUILD_DATE:=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 # ------
 ALL_ARCHITECTURES=amd64 arm arm64 ppc64le s390x
 GOLANGCI_VERSION=v1.23.6
+export DOCKER_CLI_EXPERIMENTAL=enabled
 
 # Computed variables
 # ------------------


### PR DESCRIPTION
**What this PR does / why we need it**:
Pushing multi-arch images is still a experimental feature and requires enabling in docker.
Looks like this environment variable was lost during refactors.
/cc @kawych @s-urbaniak 

