### PR TITLE
go.mod: Fix invalid go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/metrics-server
 
-go 1.13.8
+go 1.13
 
 require (
 	github.com/go-openapi/spec v0.19.3


### PR DESCRIPTION
The file only allows a minor version and with a patch version specified fails parsing with `parsing go.mod: go.mod:3: usage: go 1.23`

The closest to a spec I found was https://golang.org/cmd/go/#hdr-The_go_mod_file, which also doesn't specify the allowed range.
