### PR TITLE
Configure rolling deployment without downtime

### DIFF
--- a/deploy/kubernetes/metrics-server-deployment.yaml
+++ b/deploy/kubernetes/metrics-server-deployment.yaml
@@ -16,6 +16,9 @@ spec:
   selector:
     matchLabels:
       k8s-app: metrics-server
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
   template:
     metadata:
       name: metrics-server
@@ -38,6 +41,11 @@ spec:
         - name: main-port
           containerPort: 4443
           protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: main-port
+            scheme: HTTPS
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true

--- a/deploy/kubernetes/metrics-server-pdb.yaml
+++ b/deploy/kubernetes/metrics-server-pdb.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    k8s-app: metrics-server
+spec:
+  minAvailable: 100%
+  selector:
+    matchLabels:
+      k8s-app: metrics-server


### PR DESCRIPTION
**What this PR does / why we need it**:
* Adds readinessProbe
* Configures rollingUpdate.maxUnavailable = 0 (default is 25%)
* Adds PodDisruptionBudget with minAvailable = 100%

**Which issue(s) this PR fixes**
Fixes #395 

**Testing Info**
Not sure how to e2e test this, but I tested locally using kind and manually applying and watching the pod creation and termination.

Currently, the metrics-server pod will become ready pretty much immediately because there is no readiness probe.

With this PR's change, I saw the metrics-server pod remain running while the new pod was also running but not year ready, and then terminate only after the new pod became ready:

```
NAME                                         READY   STATUS    RESTARTS   AGE
metrics-server-58c885686f-rxw7p              1/1     Running   0          2m7s
metrics-server-7b5c967ddd-v8597              0/1     Running   0          2s
```
```
NAME                                         READY   STATUS        RESTARTS   AGE
metrics-server-58c885686f-rxw7p              0/1     Terminating   0          2m13s
metrics-server-7b5c967ddd-v8597              1/1     Running       0          8s
```
```
NAME                                         READY   STATUS    RESTARTS   AGE
metrics-server-7b5c967ddd-v8597              1/1     Running   0          10s
```

