### PR TITLE
Fix readiness check by requiring at least one node scraped

### DIFF
--- a/pkg/metrics-server/server.go
+++ b/pkg/metrics-server/server.go
@@ -100,16 +100,12 @@ func (ms *MetricsServer) scrape(startTime time.Time) {
 	data, scrapeErr := ms.scraper.Scrape(ctx)
 	if scrapeErr != nil {
 		klog.Errorf("unable to fully scrape metrics: %v", scrapeErr)
-
-		// only consider this an indication of bad health if we
-		// couldn't scrape from any nodes -- one node going down
-		// shouldn't indicate that metrics-server is unhealthy
-		if len(data.Nodes) == 0 {
-			healthyTick = false
-		}
-
 		// NB: continue on so that we don't lose all metrics
 		// if one node goes down
+	}
+	// at least one node scrape needs needs to be successful to consider metrics-server healthy
+	if data == nil || len(data.Nodes) == 0 {
+		healthyTick = false
 	}
 
 	klog.V(6).Infof("...Storing metrics...")

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -43,9 +43,6 @@ wait_for_metrics() {
   while [[ $(kubectl get pods -n kube-system -l k8s-app=metrics-server -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
     echo "waiting for pod ready" && sleep 5;
   done
-
-  # By default metrics server scrapes every 60s
-  sleep 60
 }
 
 run_tests() {


### PR DESCRIPTION
Without this change MS marked itself as healthy as list of nodes was
empty during initialization. With this change and readiness check
configured we don't need to wait in e2e tests.
/cc @loburm @s-urbaniak 
