### PR TITLE
Wait for node informer to sync allowing immediate scrape to succeed fixing readiness probe

### DIFF
--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -43,9 +43,6 @@ wait_for_metrics() {
   while [[ $(kubectl get pods -n kube-system -l k8s-app=metrics-server -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
     echo "waiting for pod ready" && sleep 5;
   done
-
-  # By default metrics server scrapes every 60s
-  sleep 60
 }
 
 run_tests() {

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -44,16 +44,10 @@ var _ = Describe("MetricsServer", func() {
 	if err != nil {
 		panic(err)
 	}
-	It("exposes metrics about all pods in cluster", func() {
-		podList, err := client.CoreV1().Pods(metav1.NamespaceAll).List(metav1.ListOptions{})
-		if err != nil {
-			panic(err)
-		}
-		Expect(podList.Items).NotTo(BeEmpty(), "Need at least one pod to verify if MetricsServer works")
-		for _, pod := range podList.Items {
-			_, err := mclient.MetricsV1beta1().PodMetricses(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred(), "Metrics for pod %s/%s are not available", pod.Namespace, pod.Name)
-		}
+	It("exposes metrics from at least one pod in cluster", func() {
+		podMetrics, err := mclient.MetricsV1beta1().PodMetricses(metav1.NamespaceAll).List(metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred(), "Failed to list pod metrics")
+		Expect(podMetrics.Items).NotTo(BeEmpty(), "Need at least one pod to verify if MetricsServer works")
 	})
 	It("exposes metrics about all nodes in cluster", func() {
 		nodeList, err := client.CoreV1().Nodes().List(metav1.ListOptions{})


### PR DESCRIPTION
With fixed readiness probe we don't need to wait in e2e tests
/cc @loburm @s-urbaniak 

