### PR TITLE
Add the feature to get KubeletPort dynamically

### DIFF
--- a/cmd/metrics-server/app/options/options.go
+++ b/cmd/metrics-server/app/options/options.go
@@ -50,6 +50,7 @@ type Options struct {
 
 	MetricResolution time.Duration
 
+	KubeletUseNodeStatusPort     bool
 	KubeletPort                  int
 	InsecureKubeletTLS           bool
 	KubeletPreferredAddressTypes []string
@@ -66,6 +67,7 @@ func (o *Options) Flags(cmd *cobra.Command) {
 
 	flags.BoolVar(&o.InsecureKubeletTLS, "kubelet-insecure-tls", o.InsecureKubeletTLS, "Do not verify CA of serving certificates presented by Kubelets.  For testing purposes only.")
 	flags.BoolVar(&o.DeprecatedCompletelyInsecureKubelet, "deprecated-kubelet-completely-insecure", o.DeprecatedCompletelyInsecureKubelet, "Do not use any encryption, authorization, or authentication when communicating with the Kubelet.")
+	flags.BoolVar(&o.KubeletUseNodeStatusPort, "kubelet-use-node-status-port", o.KubeletUseNodeStatusPort, "Use the port in the node status. Takes precedence over --kubelet-port flag.")
 	flags.IntVar(&o.KubeletPort, "kubelet-port", o.KubeletPort, "The port to use to connect to Kubelets.")
 	flags.StringVar(&o.Kubeconfig, "kubeconfig", o.Kubeconfig, "The path to the kubeconfig used to connect to the Kubernetes API server and the Kubelets (defaults to in-cluster config)")
 	flags.StringSliceVar(&o.KubeletPreferredAddressTypes, "kubelet-preferred-address-types", o.KubeletPreferredAddressTypes, "The priority of node address types to use when determining which address to use to connect to a particular node")
@@ -172,7 +174,7 @@ func (o Options) kubeletConfig(restConfig *rest.Config) *scraper.KubeletClientCo
 		kubeletRestCfg.TLSClientConfig.CAFile = o.KubeletCAFile
 		kubeletRestCfg.TLSClientConfig.CAData = nil
 	}
-	return scraper.GetKubeletConfig(kubeletRestCfg, o.KubeletPort, o.InsecureKubeletTLS, o.DeprecatedCompletelyInsecureKubelet)
+	return scraper.GetKubeletConfig(kubeletRestCfg, o.KubeletPort, o.KubeletUseNodeStatusPort, o.InsecureKubeletTLS, o.DeprecatedCompletelyInsecureKubelet)
 }
 
 func (o Options) addressResolverConfig() []corev1.NodeAddressType {

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -32,6 +32,7 @@ spec:
           - --cert-dir=/tmp
           - --secure-port=4443
           - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+          - --kubelet-use-node-status-port
         ports:
         - name: main-port
           containerPort: 4443

--- a/pkg/scraper/configs.go
+++ b/pkg/scraper/configs.go
@@ -21,7 +21,7 @@ import (
 )
 
 // GetKubeletConfig fetches connection config for connecting to the Kubelet.
-func GetKubeletConfig(cfg *rest.Config, port int, insecureTLS bool, completelyInsecure bool) *KubeletClientConfig {
+func GetKubeletConfig(cfg *rest.Config, port int, kubeletUseNodeStatusPort bool, insecureTLS bool, completelyInsecure bool) *KubeletClientConfig {
 	if completelyInsecure {
 		cfg = rest.AnonymousClientConfig(cfg)        // don't use auth to avoid leaking auth details to insecure endpoints
 		cfg.TLSClientConfig = rest.TLSClientConfig{} // empty TLS config --> no TLS
@@ -32,6 +32,7 @@ func GetKubeletConfig(cfg *rest.Config, port int, insecureTLS bool, completelyIn
 	}
 	kubeletConfig := &KubeletClientConfig{
 		Port:                         port,
+		KubeletUseNodeStatusPort:     kubeletUseNodeStatusPort,
 		RESTConfig:                   cfg,
 		DeprecatedCompletelyInsecure: completelyInsecure,
 	}
@@ -41,6 +42,7 @@ func GetKubeletConfig(cfg *rest.Config, port int, insecureTLS bool, completelyIn
 
 // KubeletClientConfig represents configuration for connecting to Kubelets.
 type KubeletClientConfig struct {
+	KubeletUseNodeStatusPort     bool
 	Port                         int
 	RESTConfig                   *rest.Config
 	DeprecatedCompletelyInsecure bool
@@ -53,5 +55,5 @@ func KubeletClientFor(config *KubeletClientConfig) (KubeletInterface, error) {
 		return nil, fmt.Errorf("unable to construct transport: %v", err)
 	}
 
-	return NewKubeletClient(transport, config.Port, config.DeprecatedCompletelyInsecure)
+	return NewKubeletClient(transport, config.Port, config.KubeletUseNodeStatusPort, config.DeprecatedCompletelyInsecure)
 }

--- a/pkg/scraper/scraper_test.go
+++ b/pkg/scraper/scraper_test.go
@@ -278,14 +278,14 @@ type fakeKubeletClient struct {
 	defaultDelay time.Duration
 }
 
-func (c *fakeKubeletClient) GetSummary(ctx context.Context, host string) (*stats.Summary, error) {
-	delay, ok := c.delay[host]
+func (c *fakeKubeletClient) GetSummary(ctx context.Context, info NodeInfo) (*stats.Summary, error) {
+	delay, ok := c.delay[info.ConnectAddress]
 	if !ok {
 		delay = c.defaultDelay
 	}
-	metrics, ok := c.metrics[host]
+	metrics, ok := c.metrics[info.ConnectAddress]
 	if !ok {
-		return nil, fmt.Errorf("Unknown host %q", host)
+		return nil, fmt.Errorf("Unknown host %q", info.ConnectAddress)
 	}
 
 	select {


### PR DESCRIPTION
**What this PR does / why we need it**:

Metrics-server now updates KubeletPort in full. For the newly emerging cloud-side clusters, KubeletPort may not be consistent, and it seems not flexible enough, so I added KubeletPort in the list process to solve this problem.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #535 

