### PR TITLE
Update image to k8s.gcr.io/metrics-server/metrics-server:v0.3.7

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -26,7 +26,7 @@ Suggested configuration:
 
 #### How to run metric-server on different architecture?
 
-Starting from `v0.3.7` docker image `k8s.gcr.io/metrics-server` should support multiple architectures via Manifests List.
+Starting from `v0.3.7` docker image `k8s.gcr.io/metrics-server/metrics-server` should support multiple architectures via Manifests List.
 List of supported architectures: `amd64`, `arm`, `arm64`, `ppc64le`, `s390x`.
 
 #### What Kubernetes versions are supported?

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Metrics Server installation manifests are uploaded with GitHub release.
 They are available as `components.yaml` asset on [Metrics Server releases] making them installable via url:
 
 ```shell
-kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.6/components.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.7/components.yaml
 ```
 
 WARNING: You should no longer use manifests from `master` branch (previously available in `deploy/kubernetes` directory).
@@ -66,7 +66,7 @@ Most useful flags:
 You can get a full list of Metrics Server configuration flags by running:
 
 ```shell
-docker run --rm k8s.gcr.io/metrics-server:v0.3.6 --help
+docker run --rm k8s.gcr.io/metrics-server/metrics-server:v0.3.7 --help
 ```
 
 This [Helm chart](https://github.com/helm/charts/tree/master/stable/metrics-server) can deploy the metric-server service in your cluster. 

--- a/manifests/release/kustomization.yaml
+++ b/manifests/release/kustomization.yaml
@@ -4,6 +4,6 @@ bases:
   - ../base
 images:
   - name: gcr.io/k8s-staging-metrics-server/metrics-server
-    newName: k8s.gcr.io/metrics-server
+    newName: k8s.gcr.io/metrics-server/metrics-server
     newTag: v0.3.7
 


### PR DESCRIPTION
Looks like image promotion process also change image path. Checked image is available.

