### PR TITLE
Fix nil pointer on config.Client.TLSClientConfig

### DIFF
--- a/cmd/metrics-server/app/options/options.go
+++ b/cmd/metrics-server/app/options/options.go
@@ -176,29 +176,29 @@ func (o Options) kubeletConfig(restConfig *rest.Config) *scraper.KubeletClientCo
 		UseNodeStatusPort:   o.KubeletUseNodeStatusPort,
 	}
 	if len(o.KubeletCAFile) > 0 {
-		config.RESTConfig.TLSClientConfig.CAFile = o.KubeletCAFile
-		config.RESTConfig.TLSClientConfig.CAData = nil
+		config.Client.TLSClientConfig.CAFile = o.KubeletCAFile
+		config.Client.TLSClientConfig.CAData = nil
 	}
 	if len(o.KubeletClientCertFile) > 0 {
-		config.RESTConfig.TLSClientConfig.CertFile = o.KubeletClientCertFile
-		config.RESTConfig.TLSClientConfig.CertData = nil
+		config.Client.TLSClientConfig.CertFile = o.KubeletClientCertFile
+		config.Client.TLSClientConfig.CertData = nil
 	}
 	if len(o.KubeletClientKeyFile) > 0 {
-		config.RESTConfig.TLSClientConfig.KeyFile = o.KubeletClientKeyFile
-		config.RESTConfig.TLSClientConfig.KeyData = nil
+		config.Client.TLSClientConfig.KeyFile = o.KubeletClientKeyFile
+		config.Client.TLSClientConfig.KeyData = nil
 	}
 	if o.DeprecatedCompletelyInsecureKubelet {
 		config.Scheme = "http"
-		config.RESTConfig = rest.AnonymousClientConfig(config.RESTConfig) // don't use auth to avoid leaking auth details to insecure endpoints
-		config.RESTConfig.TLSClientConfig = rest.TLSClientConfig{}        // empty TLS config --> no TLS
+		config.Client = *rest.AnonymousClientConfig(&config.Client) // don't use auth to avoid leaking auth details to insecure endpoints
+		config.Client.TLSClientConfig = rest.TLSClientConfig{}      // empty TLS config --> no TLS
 	} else {
 		config.Scheme = "https"
-		config.RESTConfig = rest.CopyConfig(restConfig)
+		config.Client = *rest.CopyConfig(restConfig)
 	}
 	if o.InsecureKubeletTLS {
-		config.RESTConfig.TLSClientConfig.Insecure = true
-		config.RESTConfig.TLSClientConfig.CAData = nil
-		config.RESTConfig.TLSClientConfig.CAFile = ""
+		config.Client.TLSClientConfig.Insecure = true
+		config.Client.TLSClientConfig.CAData = nil
+		config.Client.TLSClientConfig.CAFile = ""
 	}
 	return config
 }

--- a/pkg/scraper/configs.go
+++ b/pkg/scraper/configs.go
@@ -28,7 +28,7 @@ import (
 
 // KubeletClientConfig represents configuration for connecting to Kubelets.
 type KubeletClientConfig struct {
-	RESTConfig          *rest.Config
+	Client              rest.Config
 	AddressTypePriority []corev1.NodeAddressType
 	Scheme              string
 	DefaultPort         int
@@ -37,7 +37,7 @@ type KubeletClientConfig struct {
 
 // Complete constructs a new kubeletCOnfig for the given configuration.
 func (config KubeletClientConfig) Complete() (*kubeletClient, error) {
-	transport, err := rest.TransportFor(config.RESTConfig)
+	transport, err := rest.TransportFor(&config.Client)
 	if err != nil {
 		return nil, fmt.Errorf("unable to construct transport: %v", err)
 	}


### PR DESCRIPTION
If DeprecatedCompletelyInsecureKubelet is true, then config.RESTConfig which is nill is passed to AnonymousClientConfig which doesn't handle nils.
Changing pointers to composition which makes more sense for config. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
/cc @s-urbaniak 

