### PR TITLE
Remove KubeUp labels and use Kustomize commonLabels

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -4,20 +4,11 @@ kind: Deployment
 metadata:
   name: metrics-server
   namespace: kube-system
-  labels:
-    k8s-app: metrics-server
 spec:
-  selector:
-    matchLabels:
-      k8s-app: metrics-server
   strategy:
     rollingUpdate:
       maxUnavailable: 0
   template:
-    metadata:
-      name: metrics-server
-      labels:
-        k8s-app: metrics-server
     spec:
       serviceAccountName: metrics-server
       volumes:

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  k8s-app: metrics-server
 resources:
   - apiservice.yaml
   - deployment.yaml

--- a/manifests/base/pdb.yaml
+++ b/manifests/base/pdb.yaml
@@ -4,10 +4,7 @@ kind: PodDisruptionBudget
 metadata:
   name: metrics-server
   namespace: kube-system
-  labels:
-    k8s-app: metrics-server
 spec:
   minAvailable: 100%
   selector:
-    matchLabels:
-      k8s-app: metrics-server
+    matchLabels: {}

--- a/manifests/base/service.yaml
+++ b/manifests/base/service.yaml
@@ -4,12 +4,7 @@ kind: Service
 metadata:
   name: metrics-server
   namespace: kube-system
-  labels:
-    kubernetes.io/name: "Metrics-server"
-    kubernetes.io/cluster-service: "true"
 spec:
-  selector:
-    k8s-app: metrics-server
   ports:
   - port: 443
     protocol: TCP


### PR DESCRIPTION

kubernetes.io/name is KubeUp label (k/k distro for testing), we can drop them. Having commonLabels should help with making sure that all resources are annotated. 
/cc @s-urbaniak 

