### PR TITLE
Set pod priority to system-cluster-critical

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -24,6 +24,7 @@ spec:
       # mount in tmp so we can safely use from-scratch images and/or read-only containers
       - name: tmp-dir
         emptyDir: {}
+      priorityClassName: system-cluster-critical
       containers:
       - name: metrics-server
         image: gcr.io/k8s-staging-metrics-server/metrics-server:master


### PR DESCRIPTION
As part of autoscaling pipeline Metrics Server is expected to be system
critical in clusters that rely on autoscaling. system-cluster-critical
is one of the higher priorities built in kubernetes. Running in higher
priority means that metrics-server has priority when scheduling and lack
of capacity in cluster could cause pods with lower priority to be
preempted.
