### PR TITLE
pkg: dependency inject prometheus registry

### DIFF
--- a/cmd/metrics-server/app/start.go
+++ b/cmd/metrics-server/app/start.go
@@ -53,7 +53,6 @@ func runCommand(o *options.Options, stopCh <-chan struct{}) error {
 	if err != nil {
 		return err
 	}
-	config.Apiserver.EnableMetrics = true
 	// Use protobufs for communication with apiserver
 	config.Rest.ContentType = "application/vnd.kubernetes.protobuf"
 

--- a/pkg/api/monitoring.go
+++ b/pkg/api/monitoring.go
@@ -16,7 +16,6 @@ package api
 
 import (
 	"k8s.io/component-base/metrics"
-	"k8s.io/component-base/metrics/legacyregistry"
 )
 
 var (
@@ -32,6 +31,8 @@ var (
 	)
 )
 
-func init() {
-	legacyregistry.Register(metricFreshness)
+// RegisterAPIMetrics registers a histogram metric for the freshness of
+// exported metrics.
+func RegisterAPIMetrics(registrationFunc func(metrics.Registerable) error) error {
+	return registrationFunc(metricFreshness)
 }

--- a/pkg/api/node_test.go
+++ b/pkg/api/node_test.go
@@ -239,7 +239,9 @@ func TestNodeList_Monitoring(t *testing.T) {
 	c := &fakeClock{}
 	myClock = c
 
+	metricFreshness.Create(nil)
 	metricFreshness.Reset()
+
 	r := NewTestNodeStorage(createTestNodes(), nil)
 	c.now = c.now.Add(10 * time.Second)
 	_, err := r.List(genericapirequest.NewContext(), nil)

--- a/pkg/api/pod_test.go
+++ b/pkg/api/pod_test.go
@@ -212,7 +212,9 @@ func TestPodList_Monitoring(t *testing.T) {
 	c := &fakeClock{}
 	myClock = c
 
+	metricFreshness.Create(nil)
 	metricFreshness.Reset()
+
 	r := NewPodTestStorage(createTestPods(), nil)
 	c.now = c.now.Add(10 * time.Second)
 	_, err := r.List(genericapirequest.NewContext(), nil)

--- a/pkg/scraper/scraper_test.go
+++ b/pkg/scraper/scraper_test.go
@@ -148,9 +148,13 @@ var _ = Describe("Scraper", func() {
 	})
 
 	It("should properly calculates metrics", func() {
+		requestDuration.Create(nil)
+		requestTotal.Create(nil)
+		lastRequestTime.Create(nil)
 		requestDuration.Reset()
 		requestTotal.Reset()
 		lastRequestTime.Reset()
+
 		client.defaultDelay = 1 * time.Second
 		myClock = mockClock{
 			now:   time.Time{},

--- a/pkg/scraper/scraper_test.go
+++ b/pkg/scraper/scraper_test.go
@@ -163,7 +163,7 @@ var _ = Describe("Scraper", func() {
 		Expect(errs).NotTo(HaveOccurred())
 
 		err := testutil.CollectAndCompare(requestDuration, strings.NewReader(`
-		# HELP metrics_server_kubelet_request_duration_seconds [ALPHA] Duration of requests to kubelet API in seconds
+		# HELP metrics_server_kubelet_request_duration_seconds [ALPHA] Duration of requests to Kubelet API in seconds
 		# TYPE metrics_server_kubelet_request_duration_seconds histogram
 		metrics_server_kubelet_request_duration_seconds_bucket{node="node1",le="0.005"} 0
 		metrics_server_kubelet_request_duration_seconds_bucket{node="node1",le="0.01"} 0

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -17,10 +17,13 @@ import (
 	"fmt"
 	"time"
 
+	apimetrics "k8s.io/apiserver/pkg/endpoints/metrics"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/component-base/metrics"
+
 	"sigs.k8s.io/metrics-server/pkg/api"
 	"sigs.k8s.io/metrics-server/pkg/scraper"
 	"sigs.k8s.io/metrics-server/pkg/storage"
@@ -46,9 +49,12 @@ func (c Config) Complete() (*server, error) {
 	nodes := informer.Core().V1().Nodes()
 	scrape := scraper.NewScraper(nodes.Lister(), kubeletClient, c.ScrapeTimeout)
 
-	RegisterServerMetrics(c.MetricResolution)
-
 	genericServer, err := c.Apiserver.Complete(informer).New("metrics-server", genericapiserver.NewEmptyDelegate())
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.installMetrics(genericServer)
 	if err != nil {
 		return nil, err
 	}
@@ -65,6 +71,22 @@ func (c Config) Complete() (*server, error) {
 		scrape,
 		c.MetricResolution,
 	), nil
+}
+
+func (c Config) installMetrics(s *genericapiserver.GenericAPIServer) error {
+	registry := metrics.NewKubeRegistry()
+	err := scraper.RegisterScraperMetrics(registry.Register)
+	if err != nil {
+		return fmt.Errorf("unable to register scraper metrics: %v", err)
+	}
+	err = RegisterServerMetrics(registry.Register, c.MetricResolution)
+	if err != nil {
+		return fmt.Errorf("unable to register server metrics: %v", err)
+	}
+	apimetrics.Register()
+
+	DefaultMetrics{registry}.Install(s.Handler.NonGoRestfulMux)
+	return nil
 }
 
 func (c Config) informer() (informers.SharedInformerFactory, error) {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -75,14 +75,26 @@ func (c Config) Complete() (*server, error) {
 
 func (c Config) installMetrics(s *genericapiserver.GenericAPIServer) error {
 	registry := metrics.NewKubeRegistry()
-	err := scraper.RegisterScraperMetrics(registry.Register)
-	if err != nil {
-		return fmt.Errorf("unable to register scraper metrics: %v", err)
-	}
-	err = RegisterServerMetrics(registry.Register, c.MetricResolution)
+
+	// register metrics server components metrics
+	err := RegisterServerMetrics(registry.Register, c.MetricResolution)
 	if err != nil {
 		return fmt.Errorf("unable to register server metrics: %v", err)
 	}
+	err = scraper.RegisterScraperMetrics(registry.Register)
+	if err != nil {
+		return fmt.Errorf("unable to register scraper metrics: %v", err)
+	}
+	err = api.RegisterAPIMetrics(registry.Register)
+	if err != nil {
+		return fmt.Errorf("unable to register API metrics: %v", err)
+	}
+	err = storage.RegisterStorageMetrics(registry.Register)
+	if err != nil {
+		return fmt.Errorf("unable to register storage metrics: %v", err)
+	}
+
+	// register apiserver metrics
 	apimetrics.Register()
 
 	DefaultMetrics{registry}.Install(s.Handler.NonGoRestfulMux)

--- a/pkg/server/metrics.go
+++ b/pkg/server/metrics.go
@@ -1,0 +1,47 @@
+// Copyright 2020 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"net/http"
+
+	apimetrics "k8s.io/apiserver/pkg/endpoints/metrics"
+	"k8s.io/apiserver/pkg/server/mux"
+	etcd3metrics "k8s.io/apiserver/pkg/storage/etcd3/metrics"
+	flowcontrolmetrics "k8s.io/apiserver/pkg/util/flowcontrol/metrics"
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+// DefaultMetrics installs the default prometheus metrics handler
+type DefaultMetrics struct {
+	registry metrics.Gatherer
+}
+
+// Install adds the DefaultMetrics handler
+func (m DefaultMetrics) Install(c *mux.PathRecorderMux) {
+	register()
+	c.HandleFunc("/metrics", func(w http.ResponseWriter, req *http.Request) {
+		legacyregistry.Handler().ServeHTTP(w, req)
+		metrics.HandlerFor(m.registry, metrics.HandlerOpts{}).ServeHTTP(w, req)
+	})
+}
+
+// register apiserver and etcd metrics
+func register() {
+	apimetrics.Register()
+	etcd3metrics.Register()
+	flowcontrolmetrics.Register()
+}

--- a/pkg/server/metrics.go
+++ b/pkg/server/metrics.go
@@ -17,10 +17,7 @@ package server
 import (
 	"net/http"
 
-	apimetrics "k8s.io/apiserver/pkg/endpoints/metrics"
 	"k8s.io/apiserver/pkg/server/mux"
-	etcd3metrics "k8s.io/apiserver/pkg/storage/etcd3/metrics"
-	flowcontrolmetrics "k8s.io/apiserver/pkg/util/flowcontrol/metrics"
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 )
@@ -32,16 +29,8 @@ type DefaultMetrics struct {
 
 // Install adds the DefaultMetrics handler
 func (m DefaultMetrics) Install(c *mux.PathRecorderMux) {
-	register()
 	c.HandleFunc("/metrics", func(w http.ResponseWriter, req *http.Request) {
 		legacyregistry.Handler().ServeHTTP(w, req)
 		metrics.HandlerFor(m.registry, metrics.HandlerOpts{}).ServeHTTP(w, req)
 	})
-}
-
-// register apiserver and etcd metrics
-func register() {
-	apimetrics.Register()
-	etcd3metrics.Register()
-	flowcontrolmetrics.Register()
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/component-base/metrics"
-	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog"
 
 	"sigs.k8s.io/metrics-server/pkg/scraper"
@@ -40,9 +39,9 @@ var (
 	tickDuration *metrics.Histogram = metrics.NewHistogram(&metrics.HistogramOpts{})
 )
 
-// RegisterTickDuration creates and registers a histogram metric for
+// RegisterServerMetrics creates and registers a histogram metric for
 // scrape duration.
-func RegisterServerMetrics(resolution time.Duration) {
+func RegisterServerMetrics(registrationFunc func(metrics.Registerable) error, resolution time.Duration) error {
 	tickDuration = metrics.NewHistogram(
 		&metrics.HistogramOpts{
 			Namespace: "metrics_server",
@@ -52,7 +51,7 @@ func RegisterServerMetrics(resolution time.Duration) {
 			Buckets:   utils.BucketsForScrapeDuration(resolution),
 		},
 	)
-	legacyregistry.MustRegister(tickDuration)
+	return registrationFunc(tickDuration)
 }
 
 func NewServer(

--- a/pkg/storage/monitoring.go
+++ b/pkg/storage/monitoring.go
@@ -16,7 +16,6 @@ package storage
 
 import (
 	"k8s.io/component-base/metrics"
-	"k8s.io/component-base/metrics/legacyregistry"
 )
 
 var (
@@ -31,6 +30,8 @@ var (
 	)
 )
 
-func init() {
-	legacyregistry.Register(pointsStored)
+// RegisterStorageMetrics registers a gauge metric for the number of metrics
+// points stored.
+func RegisterStorageMetrics(registrationFunc func(metrics.Registerable) error) error {
+	return registrationFunc(pointsStored)
 }

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -303,7 +303,9 @@ var _ = Describe("In-memory storage", func() {
 
 	})
 	It("should properly calculate metrics", func() {
+		pointsStored.Create(nil)
 		pointsStored.Reset()
+
 		storage.Store(batch)
 
 		err := testutil.CollectAndCompare(pointsStored, strings.NewReader(`


### PR DESCRIPTION
Replace the global Prometheus registry by dependency injecting a registry into each component to conform to the metrics overhaul guidelines.

Fixes #449

/cc @s-urbaniak 
