### PR TITLE
github: add spoiler tags to bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -15,11 +15,35 @@ about: Report a bug encountered while operating Metrics Server
 
 **Environment**:
 - Kubernetes distribution (GKE, EKS, Kubeadm, the hard way, etc.):
-- Container Network Setup (flannel, calico, etc.): 
+- Container Network Setup (flannel, calico, etc.):
 - Kubernetes version (use `kubectl version`):
-- Metrics Server manifest:
+
+- Metrics Server manifest
+
+<details>
+  <summary>spoiler for Metrics Server manifest:</summary>
+
+  <!--- INSERT manifest HERE --->
+
+</details>
+
 - Kubelet config:
-- Metrics Server logs:
+
+<details>
+  <summary>spoiler for Kubelet config:</summary>
+
+  <!--- INSERT kubelet config HERE --->
+
+</details>
+
+- Metrics server logs:
+
+<details>
+  <summary>spoiler for Metrics Server logs:</summary>
+
+  <!--- INSERT logs HERE --->
+
+</details>
 
 <!-- DO NOT EDIT BELOW THIS LINE -->
 /kind bug


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

## Description

**What this PR does / why we need it**:

- long logs of output or long configs are hard on the eyes and make it
  difficult to read through issues as they take up a lot of space
  - so it would be better, in my opinion, to hide them by default with
    spoiler tags, which can be opened up when further investigation is
    warranted
- I used this in an issue I've reported here and have also done this
  and implemented this in other repos

## Tags

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

Can see examples of spoiler tag usage in my own #541 

Can see examples of very long output logs and/or configs in #417, #424, etc

A similar example is in https://github.com/ezolenko/rollup-plugin-typescript2/pull/244 as well.

## Review Notes

Feel free to reject this if you don't think it'll be that useful in this context, thought I'd suggest it at least.


[See Rendered Version](https://github.com/kubernetes-sigs/metrics-server/blob/52ad541467f18c7528f308ca143ec08669e9620b/.github/ISSUE_TEMPLATE/bug-report.md)
The spoiler tags aren't properly indented unfortunately. While you _can_ indent them under the bullets, the logs themselves then need to be indented as well, which I think is too difficult for users and so will be ignored. If the logs aren't indented, then they don't make it into the spoiler tag anyway 😕  . So I think having them unindented and allowing for straight copy+paste is better, but does look a bit funky. Suggestions welcome.