### PR TITLE
Disable default metrics handler

### DIFF
--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -93,8 +93,6 @@ var _ = Describe("MetricsServer", func() {
 			"apiserver_client_certificate_expiration_seconds",
 			"apiserver_current_inflight_requests",
 			"apiserver_envelope_encryption_dek_cache_fill_percent",
-			"apiserver_flowcontrol_read_vs_write_request_count_samples",
-			"apiserver_flowcontrol_read_vs_write_request_count_watermarks",
 			"apiserver_request_duration_seconds",
 			"apiserver_request_total",
 			"apiserver_response_sizes",


### PR DESCRIPTION
Refactor code to make overriding metrics handler more visible
Remove 2 apiserver metrics to make tests pass, not sure why they are no
longer reported, but they are irrelevant for apiserver.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #630

@dgrisonnet @s-urbaniak 
