### PR TITLE
Improve quality of autoscaling in default configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Metrics Server is not meant for non-autoscaling purposes. For example, don't use
 Metrics Server offers:
 - A single deployment that works on most clusters (see [Requirements](#requirements))
 - Scalable support up to 5,000 node clusters
-- Resource efficiency: Metrics Server uses 0.5m core of CPU and 4 MB of memory per node
+- Resource efficiency: Metrics Server uses 1m core of CPU and 3 MB of memory per node
 
 ## Use cases
 
@@ -55,6 +55,32 @@ Metrics Server | Metrics API group/version | Supported Kubernetes version
 ---------------|---------------------------|-----------------------------
 0.4.x          | `metrics.k8s.io/v1beta1`  | 1.8+
 0.3.x          | `metrics.k8s.io/v1beta1`  | 1.8+
+
+## Scaling
+
+Starting from v0.5.0 Metrics Server comes with default resource requests that should guarantee good performance for most cluster configurations up to 100 nodes:
+
+* 100m core of CPU
+* 300MiB of memory
+
+If neeed resources can be scaled proportionally based on the number of nodes (minimum of 10 nodes).
+For example, clusters up to 10 nodes can request 10m core CPU and 30MiB memory.
+Please remember that lowering resources will also proportionally reduce other thresholds like maximum number of autoscaled deployments (down to 10 for 10 node clusters).
+
+Metrics Server resource usage depends on multiple independent dimensions, creating a [Scalability Envelope].
+Default Metrics Server configuration should work in clusters that don't exceed any of the thresholds listed below:
+
+[Scalability Envelope]: https://github.com/kubernetes/community/blob/master/sig-scalability/configs-and-limits/thresholds.md
+
+Quantity            | Namespace threshold | Cluster threshold
+--------------------|---------------------|------------------
+# Nodes             | n/a                 | 100
+# Pods              | 7000                | 7000
+# Deployments + HPA | 100                 | 100
+
+For clusters of more than 100 nodes, allocate additionally:
+* 1m core per node
+* 3MiB memory per node
 
 ### Configuration 
 

--- a/manifests/autoscale/patch.yaml
+++ b/manifests/autoscale/patch.yaml
@@ -28,14 +28,14 @@ spec:
                   fieldPath: metadata.namespace
           command:
             - /pod_nanny
-            - --cpu=10m
+            - --cpu=4m
             - --extra-cpu=1m
-            - --memory=25Mi
-            - --extra-memory=0.75Mi
+            - --memory=15Mi
+            - --extra-memory=3Mi
             - --threshold=5
             - --deployment=metrics-server
             - --container=metrics-server
             - --poll-period=300000
             - --estimator=exponential
-            - --minClusterSize=16
+            - --minClusterSize=10
             - --use-metrics=true

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -25,6 +25,11 @@ spec:
           - --secure-port=4443
           - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
           - --kubelet-use-node-status-port
+          - --metric-resolution=15s
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
         ports:
         - name: https
           containerPort: 4443


### PR DESCRIPTION
* Increase metric resolution to 15s
* Assign default resource requests
* Document scalability dimensions

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/metrics-server/issues/642

