### PR TITLE
Watch only metadata for pods

### DIFF
--- a/cmd/metrics-server/app/start.go
+++ b/cmd/metrics-server/app/start.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"k8s.io/apiserver/pkg/server/healthz"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/term"
 	"k8s.io/klog/v2"
@@ -90,9 +89,5 @@ func runCommand(o *options.Options, stopCh <-chan struct{}) error {
 		return err
 	}
 
-	err = s.AddHealthChecks(healthz.NamedCheck("livez", s.CheckLiveness), healthz.NamedCheck("readyz", s.CheckReadiness))
-	if err != nil {
-		return err
-	}
 	return s.RunUntil(stopCh)
 }

--- a/pkg/api/pod.go
+++ b/pkg/api/pod.go
@@ -254,10 +254,6 @@ func (m *podMetrics) getPodMetrics(pods ...*v1.Pod) ([]metrics.PodMetrics, error
 	res := make([]metrics.PodMetrics, 0, len(pods))
 
 	for i, pod := range pods {
-		if pod.Status.Phase != v1.PodRunning {
-			// ignore pod not in Running phase
-			continue
-		}
 		if containerMetrics[i] == nil {
 			continue
 		}

--- a/pkg/api/pod_test.go
+++ b/pkg/api/pod_test.go
@@ -204,28 +204,6 @@ func TestPodList_WithFieldSelectors(t *testing.T) {
 	}
 }
 
-func TestPodList_PodNotRunning(t *testing.T) {
-	// setup
-	pods := createTestPods()
-	pods[1].Status.Phase = v1.PodPending
-
-	r := NewPodTestStorage(pods, nil)
-
-	// execute
-	got, err := r.List(genericapirequest.NewContext(), nil)
-
-	// assert
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	res := got.(*metrics.PodMetricsList)
-
-	if len(res.Items) != 2 ||
-		res.Items[0].Name != "pod1" ||
-		res.Items[1].Name != "pod3" {
-		t.Errorf("Got unexpected object: %+v", got)
-	}
-}
 func TestPodList_Monitoring(t *testing.T) {
 	c := &fakeClock{}
 	myClock = c

--- a/pkg/server/health.go
+++ b/pkg/server/health.go
@@ -1,0 +1,60 @@
+// Copyright 2021 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"fmt"
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/server/healthz"
+)
+
+type cacheSyncWaiter interface {
+	WaitForCacheSync(stopCh <-chan struct{}) map[schema.GroupVersionResource]bool
+}
+
+type metadataInformerSync struct {
+	cacheSyncWaiter cacheSyncWaiter
+}
+
+var _ healthz.HealthChecker = &metadataInformerSync{}
+
+// MetadataInformerSyncHealthz returns a new HealthChecker that will pass only if all informers in the given cacheSyncWaiter sync.
+func MetadataInformerSyncHealthz(cacheSyncWaiter cacheSyncWaiter) healthz.HealthChecker {
+	return &metadataInformerSync{
+		cacheSyncWaiter: cacheSyncWaiter,
+	}
+}
+
+func (i *metadataInformerSync) Name() string {
+	return "metadata-informer-sync"
+}
+
+func (i *metadataInformerSync) Check(_ *http.Request) error {
+	stopCh := make(chan struct{})
+	// Close stopCh to force checking if informers are synced now.
+	close(stopCh)
+
+	informersByStarted := make(map[bool][]string)
+	for informerType, started := range i.cacheSyncWaiter.WaitForCacheSync(stopCh) {
+		informersByStarted[started] = append(informersByStarted[started], informerType.String())
+	}
+
+	if notStarted := informersByStarted[false]; len(notStarted) > 0 {
+		return fmt.Errorf("%d informers not started yet: %v", len(notStarted), notStarted)
+	}
+	return nil
+}

--- a/pkg/server/informer.go
+++ b/pkg/server/informer.go
@@ -1,0 +1,121 @@
+// Copyright 2021 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/metadata"
+	"k8s.io/client-go/metadata/metadatainformer"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	// we should never need to resync, since we're not worried about missing events,
+	// and resync is actually for regular interval-based reconciliation these days,
+	// so set the default resync interval to 0
+	defaultResync = 0
+)
+
+func informerFactory(rest *rest.Config) (informers.SharedInformerFactory, error) {
+	client, err := kubernetes.NewForConfig(rest)
+	if err != nil {
+		return nil, fmt.Errorf("unable to construct lister client: %v", err)
+	}
+	return informers.NewSharedInformerFactory(client, defaultResync), nil
+}
+
+func runningPodMetadataInformer(rest *rest.Config) (metadatainformer.SharedInformerFactory, error) {
+	client, err := metadata.NewForConfig(rest)
+	if err != nil {
+		return nil, fmt.Errorf("unable to construct lister client: %v", err)
+	}
+	return metadatainformer.NewFilteredSharedInformerFactory(client, defaultResync, corev1.NamespaceAll, func(options *metav1.ListOptions) {
+		options.FieldSelector = "status.phase=Running"
+	}), nil
+}
+
+type podMetadataLister struct {
+	cache.GenericLister
+}
+
+// podMetadataLister should implement podLister interface
+var _ corelisters.PodLister = (*podMetadataLister)(nil)
+
+func (l *podMetadataLister) List(selector labels.Selector) ([]*corev1.Pod, error) {
+	objs, err := l.GenericLister.List(selector)
+	if err != nil {
+		return nil, err
+	}
+	return pods(objs), nil
+}
+
+func (l *podMetadataLister) Pods(namespace string) corelisters.PodNamespaceLister {
+	return &podNamespaceMetadataLister{
+		GenericNamespaceLister: l.GenericLister.ByNamespace(namespace),
+	}
+}
+
+type podNamespaceMetadataLister struct {
+	cache.GenericNamespaceLister
+}
+
+var _ corelisters.PodNamespaceLister = (*podNamespaceMetadataLister)(nil)
+
+func (l *podNamespaceMetadataLister) List(selector labels.Selector) ([]*corev1.Pod, error) {
+	objs, err := l.GenericNamespaceLister.List(selector)
+	if err != nil {
+		return nil, err
+	}
+	return pods(objs), nil
+}
+
+func (l *podNamespaceMetadataLister) Get(name string) (*corev1.Pod, error) {
+	obj, err := l.GenericNamespaceLister.Get(name)
+	if err != nil {
+		return nil, err
+	}
+	meta, ok := obj.(*metav1.PartialObjectMetadata)
+	if !ok {
+		return nil, fmt.Errorf("expected PartialObjectMetadata, got: %T", obj)
+	}
+	return &corev1.Pod{
+		TypeMeta:   meta.TypeMeta,
+		ObjectMeta: meta.ObjectMeta,
+	}, nil
+}
+
+func pods(objs []runtime.Object) []*corev1.Pod {
+	pods := make([]*corev1.Pod, 0, len(objs))
+	for _, obj := range objs {
+		meta, ok := obj.(*metav1.PartialObjectMetadata)
+		if !ok {
+			continue
+		}
+		pods = append(pods, &corev1.Pod{
+			TypeMeta:   meta.TypeMeta,
+			ObjectMeta: meta.ObjectMeta,
+		})
+	}
+	return pods
+}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -88,6 +88,7 @@ var _ = Describe("MetricsServer", func() {
 [+]poststarthook/max-in-flight-filter ok
 [+]livez excluded: ok
 [+]readyz ok
+[+]metadata-informer-sync ok
 [+]shutdown ok
 readyz check passed
 `)
@@ -103,6 +104,7 @@ readyz check passed
 [+]poststarthook/max-in-flight-filter ok
 [+]livez ok
 [+]readyz excluded: ok
+[+]metadata-informer-sync ok
 livez check passed
 `)
 		Expect(diff == "").To(BeTrue(), "Unexpected response %s", diff)


### PR DESCRIPTION
Metrics Server requires pod metadata to filter pods by label
selectors. Pod Spec and Status are not used, thus we can replace normal
informer with metadata informer which avoids parsing and storing them in
memory. Only field that from status that is used if to filter if pod is
running, but this can be done on as field selector.
    
This reduces memory usage by over 40% and removes memory overhead of
watching pods in Terminated state.
/assign @s-urbaniak 

