### PR TITLE
Enable restclient metrics in metrics output

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 
+	_ "k8s.io/component-base/metrics/prometheus/restclient" // for client-go metrics registration
+
 	"sigs.k8s.io/metrics-server/pkg/api"
 	"sigs.k8s.io/metrics-server/pkg/scraper"
 	"sigs.k8s.io/metrics-server/pkg/storage"

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -144,6 +144,10 @@ var _ = Describe("MetricsServer", func() {
 			"process_start_time_seconds",
 			"process_virtual_memory_bytes",
 			"process_virtual_memory_max_bytes",
+			"rest_client_exec_plugin_certificate_rotation_age",
+			"rest_client_exec_plugin_ttl_seconds",
+			"rest_client_request_duration_seconds",
+			"rest_client_requests_total",
 		}), "Unexpected metrics")
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Enable restclient metrics in metrics output

**Which issue(s) this PR fixes**:
Fixes #636

/kind feature