### PR TITLE
Revert "Remove unused error"

### DIFF
--- a/pkg/api/interfaces.go
+++ b/pkg/api/interfaces.go
@@ -51,7 +51,7 @@ type PodMetricsGetter interface {
 	// GetContainerMetrics gets the latest metrics for all containers in each listed pod,
 	// returning both the metrics and the associated collection timestamp.
 	// If a pod is missing, the container metrics should be nil for that pod.
-	GetContainerMetrics(pods ...apitypes.NamespacedName) ([]TimeInfo, [][]metrics.ContainerMetrics)
+	GetContainerMetrics(pods ...apitypes.NamespacedName) ([]TimeInfo, [][]metrics.ContainerMetrics, error)
 }
 
 // NodeMetricsGetter knows how to fetch metrics for a node.
@@ -59,5 +59,5 @@ type NodeMetricsGetter interface {
 	// GetNodeMetrics gets the latest metrics for the given nodes,
 	// returning both the metrics and the associated collection timestamp.
 	// If a node is missing, the resourcelist should be nil for that node.
-	GetNodeMetrics(nodes ...string) ([]TimeInfo, []corev1.ResourceList)
+	GetNodeMetrics(nodes ...string) ([]TimeInfo, []corev1.ResourceList, error)
 }

--- a/pkg/api/node.go
+++ b/pkg/api/node.go
@@ -205,7 +205,11 @@ func (m *nodeMetrics) getNodeMetrics(nodes ...*v1.Node) ([]metrics.NodeMetrics, 
 	for i, node := range nodes {
 		names[i] = node.Name
 	}
-	timestamps, usages := m.metrics.GetNodeMetrics(names...)
+	timestamps, usages, err := m.metrics.GetNodeMetrics(names...)
+	if err != nil {
+		return nil, err
+	}
+
 	res := make([]metrics.NodeMetrics, 0, len(names))
 
 	for i, node := range nodes {

--- a/pkg/api/node_test.go
+++ b/pkg/api/node_test.go
@@ -63,8 +63,8 @@ type fakeNodeMetricsGetter struct {
 
 var _ NodeMetricsGetter = (*fakeNodeMetricsGetter)(nil)
 
-func (mp fakeNodeMetricsGetter) GetNodeMetrics(nodes ...string) ([]TimeInfo, []v1.ResourceList) {
-	return mp.time, mp.resources
+func (mp fakeNodeMetricsGetter) GetNodeMetrics(nodes ...string) ([]TimeInfo, []v1.ResourceList, error) {
+	return mp.time, mp.resources, nil
 }
 
 func NewTestNodeStorage(resp interface{}, err error) *nodeMetrics {

--- a/pkg/api/pod.go
+++ b/pkg/api/pod.go
@@ -245,7 +245,11 @@ func (m *podMetrics) getPodMetrics(pods ...*v1.Pod) ([]metrics.PodMetrics, error
 			Namespace: pod.Namespace,
 		}
 	}
-	timestamps, containerMetrics := m.metrics.GetContainerMetrics(namespacedNames...)
+	timestamps, containerMetrics, err := m.metrics.GetContainerMetrics(namespacedNames...)
+	if err != nil {
+		return nil, err
+	}
+
 	res := make([]metrics.PodMetrics, 0, len(pods))
 
 	for i, pod := range pods {

--- a/pkg/api/pod_test.go
+++ b/pkg/api/pod_test.go
@@ -62,8 +62,8 @@ type fakePodMetricsGetter struct {
 
 var _ PodMetricsGetter = (*fakePodMetricsGetter)(nil)
 
-func (mp fakePodMetricsGetter) GetContainerMetrics(pods ...apitypes.NamespacedName) ([]TimeInfo, [][]metrics.ContainerMetrics) {
-	return mp.time, mp.metrics
+func (mp fakePodMetricsGetter) GetContainerMetrics(pods ...apitypes.NamespacedName) ([]TimeInfo, [][]metrics.ContainerMetrics, error) {
+	return mp.time, mp.metrics, nil
 }
 
 func NewPodTestStorage(resp interface{}, err error) *podMetrics {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -124,10 +124,10 @@ var _ storage.Storage = (*storageMock)(nil)
 
 func (s *storageMock) Store(batch *storage.MetricsBatch) {}
 
-func (s *storageMock) GetContainerMetrics(pods ...apitypes.NamespacedName) ([]api.TimeInfo, [][]metrics.ContainerMetrics) {
-	return nil, nil
+func (s *storageMock) GetContainerMetrics(pods ...apitypes.NamespacedName) ([]api.TimeInfo, [][]metrics.ContainerMetrics, error) {
+	return nil, nil, nil
 }
 
-func (s *storageMock) GetNodeMetrics(nodes ...string) ([]api.TimeInfo, []corev1.ResourceList) {
-	return nil, nil
+func (s *storageMock) GetNodeMetrics(nodes ...string) ([]api.TimeInfo, []corev1.ResourceList, error) {
+	return nil, nil, nil
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -48,7 +48,7 @@ func NewStorage() *storage {
 // TODO(directxman12): figure out what the right value is for "window" --
 // we don't get the actual window from cAdvisor, so we could just
 // plumb down metric resolution, but that wouldn't be actually correct.
-func (p *storage) GetNodeMetrics(nodes ...string) ([]api.TimeInfo, []corev1.ResourceList) {
+func (p *storage) GetNodeMetrics(nodes ...string) ([]api.TimeInfo, []corev1.ResourceList, error) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
@@ -71,10 +71,10 @@ func (p *storage) GetNodeMetrics(nodes ...string) ([]api.TimeInfo, []corev1.Reso
 		}
 	}
 
-	return timestamps, resMetrics
+	return timestamps, resMetrics, nil
 }
 
-func (p *storage) GetContainerMetrics(pods ...apitypes.NamespacedName) ([]api.TimeInfo, [][]metrics.ContainerMetrics) {
+func (p *storage) GetContainerMetrics(pods ...apitypes.NamespacedName) ([]api.TimeInfo, [][]metrics.ContainerMetrics, error) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
@@ -112,7 +112,7 @@ func (p *storage) GetContainerMetrics(pods ...apitypes.NamespacedName) ([]api.Ti
 		}
 		resMetrics[i] = contMetrics
 	}
-	return timestamps, resMetrics
+	return timestamps, resMetrics, nil
 }
 
 func (p *storage) Store(batch *MetricsBatch) {


### PR DESCRIPTION
This reverts commit cb807c5e25e642929796d71e5c0b0bf2cc4ae52b. The error
is useful for other implementations of this API that don't use internal storage.

CC @serathius 