### PR TITLE
Rewrite MS to use cumulative metric

### DIFF
--- a/pkg/scraper/decode.go
+++ b/pkg/scraper/decode.go
@@ -118,11 +118,11 @@ func decodePodStats(podStats *PodStats, target *storage.PodMetricsPoint) (succes
 }
 
 func decodeCPU(target *resource.Quantity, cpuStats *CPUStats) error {
-	if cpuStats == nil || cpuStats.UsageNanoCores == nil {
-		return fmt.Errorf("missing usageNanoCores value")
+	if cpuStats == nil || cpuStats.UsageCoreNanoSeconds == nil {
+		return fmt.Errorf("missing usageCoreNanoSeconds value")
 	}
 
-	*target = *uint64Quantity(*cpuStats.UsageNanoCores, -9)
+	*target = *uint64Quantity(*cpuStats.UsageCoreNanoSeconds, -9)
 	return nil
 }
 

--- a/pkg/scraper/decode_test.go
+++ b/pkg/scraper/decode_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Decode", func() {
 		By("removing some data from the raw summary")
 		summary.Node.Memory = nil
 		summary.Pods[0].Containers[1].CPU = nil
-		summary.Pods[1].Containers[0].CPU.UsageNanoCores = nil
+		summary.Pods[1].Containers[0].CPU.UsageCoreNanoSeconds = nil
 		summary.Pods[2].Containers[0].Memory = nil
 		summary.Pods[3].Containers[0].Memory.WorkingSetBytes = nil
 
@@ -94,9 +94,9 @@ var _ = Describe("Decode", func() {
 		minusTen := uint64(math.MaxUint64 - 10)
 		minusOneHundred := uint64(math.MaxUint64 - 100)
 
-		summary.Node.Memory.WorkingSetBytes = &plusTen // RAM is cheap, right?
-		summary.Node.CPU.UsageNanoCores = &plusTwenty  // a mainframe, probably
-		summary.Pods[0].Containers[1].CPU.UsageNanoCores = &minusTen
+		summary.Node.Memory.WorkingSetBytes = &plusTen      // RAM is cheap, right?
+		summary.Node.CPU.UsageCoreNanoSeconds = &plusTwenty // a mainframe, probably
+		summary.Pods[0].Containers[1].CPU.UsageCoreNanoSeconds = &minusTen
 		summary.Pods[1].Containers[0].Memory.WorkingSetBytes = &minusOneHundred
 
 		By("decoding")
@@ -114,10 +114,10 @@ var _ = Describe("Decode", func() {
 	})
 })
 
-func cpuStats(usageNanocores uint64, ts time.Time) *CPUStats {
+func cpuStats(usageCoreNanoSeconds uint64, ts time.Time) *CPUStats {
 	return &CPUStats{
-		Time:           metav1.Time{Time: ts},
-		UsageNanoCores: &usageNanocores,
+		Time:                 metav1.Time{Time: ts},
+		UsageCoreNanoSeconds: &usageCoreNanoSeconds,
 	}
 }
 

--- a/pkg/scraper/types.go
+++ b/pkg/scraper/types.go
@@ -70,10 +70,9 @@ type PodReference struct {
 type CPUStats struct {
 	// The time at which these stats were updated.
 	Time metav1.Time `json:"time"`
-	// Total CPU usage (sum of all cores) averaged over the sample window.
-	// The "core" unit can be interpreted as CPU core-nanoseconds per second.
+	// Cumulative CPU usage (sum of all cores) since object creation.
 	// +optional
-	UsageNanoCores *uint64 `json:"usageNanoCores,omitempty"`
+	UsageCoreNanoSeconds *uint64 `json:"usageCoreNanoSeconds,omitempty"`
 }
 
 // MemoryStats contains data about memory usage.

--- a/pkg/scraper/types_easyjson.go
+++ b/pkg/scraper/types_easyjson.go
@@ -4,7 +4,6 @@ package scraper
 
 import (
 	json "encoding/json"
-
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	jwriter "github.com/mailru/easyjson/jwriter"
@@ -29,7 +28,7 @@ func easyjson6601e8cdDecodeSigsK8sIoMetricsServerPkgScraper(in *jlexer.Lexer, ou
 	}
 	in.Delim('{')
 	for !in.IsDelim('}') {
-		key := in.UnsafeString()
+		key := in.UnsafeFieldName(false)
 		in.WantColon()
 		if in.IsNull() {
 			in.Skip()
@@ -134,7 +133,7 @@ func easyjson6601e8cdDecodeSigsK8sIoMetricsServerPkgScraper1(in *jlexer.Lexer, o
 	}
 	in.Delim('{')
 	for !in.IsDelim('}') {
-		key := in.UnsafeString()
+		key := in.UnsafeFieldName(false)
 		in.WantColon()
 		if in.IsNull() {
 			in.Skip()
@@ -239,7 +238,7 @@ func easyjson6601e8cdDecodeSigsK8sIoMetricsServerPkgScraper2(in *jlexer.Lexer, o
 	}
 	in.Delim('{')
 	for !in.IsDelim('}') {
-		key := in.UnsafeString()
+		key := in.UnsafeFieldName(false)
 		in.WantColon()
 		if in.IsNull() {
 			in.Skip()
@@ -312,7 +311,7 @@ func easyjson6601e8cdDecodeSigsK8sIoMetricsServerPkgScraper3(in *jlexer.Lexer, o
 	}
 	in.Delim('{')
 	for !in.IsDelim('}') {
-		key := in.UnsafeString()
+		key := in.UnsafeFieldName(false)
 		in.WantColon()
 		if in.IsNull() {
 			in.Skip()
@@ -408,7 +407,7 @@ func easyjson6601e8cdDecodeSigsK8sIoMetricsServerPkgScraper4(in *jlexer.Lexer, o
 	}
 	in.Delim('{')
 	for !in.IsDelim('}') {
-		key := in.UnsafeString()
+		key := in.UnsafeFieldName(false)
 		in.WantColon()
 		if in.IsNull() {
 			in.Skip()
@@ -491,7 +490,7 @@ func easyjson6601e8cdDecodeSigsK8sIoMetricsServerPkgScraper5(in *jlexer.Lexer, o
 	}
 	in.Delim('{')
 	for !in.IsDelim('}') {
-		key := in.UnsafeString()
+		key := in.UnsafeFieldName(false)
 		in.WantColon()
 		if in.IsNull() {
 			in.Skip()
@@ -587,7 +586,7 @@ func easyjson6601e8cdDecodeSigsK8sIoMetricsServerPkgScraper6(in *jlexer.Lexer, o
 	}
 	in.Delim('{')
 	for !in.IsDelim('}') {
-		key := in.UnsafeString()
+		key := in.UnsafeFieldName(false)
 		in.WantColon()
 		if in.IsNull() {
 			in.Skip()
@@ -599,15 +598,15 @@ func easyjson6601e8cdDecodeSigsK8sIoMetricsServerPkgScraper6(in *jlexer.Lexer, o
 			if data := in.Raw(); in.Ok() {
 				in.AddError((out.Time).UnmarshalJSON(data))
 			}
-		case "usageNanoCores":
+		case "usageCoreNanoSeconds":
 			if in.IsNull() {
 				in.Skip()
-				out.UsageNanoCores = nil
+				out.UsageCoreNanoSeconds = nil
 			} else {
-				if out.UsageNanoCores == nil {
-					out.UsageNanoCores = new(uint64)
+				if out.UsageCoreNanoSeconds == nil {
+					out.UsageCoreNanoSeconds = new(uint64)
 				}
-				*out.UsageNanoCores = uint64(in.Uint64())
+				*out.UsageCoreNanoSeconds = uint64(in.Uint64())
 			}
 		default:
 			in.SkipRecursive()
@@ -628,10 +627,10 @@ func easyjson6601e8cdEncodeSigsK8sIoMetricsServerPkgScraper6(out *jwriter.Writer
 		out.RawString(prefix[1:])
 		out.Raw((in.Time).MarshalJSON())
 	}
-	if in.UsageNanoCores != nil {
-		const prefix string = ",\"usageNanoCores\":"
+	if in.UsageCoreNanoSeconds != nil {
+		const prefix string = ",\"usageCoreNanoSeconds\":"
 		out.RawString(prefix)
-		out.Uint64(uint64(*in.UsageNanoCores))
+		out.Uint64(uint64(*in.UsageCoreNanoSeconds))
 	}
 	out.RawByte('}')
 }

--- a/pkg/scraper/types_test.go
+++ b/pkg/scraper/types_test.go
@@ -120,8 +120,8 @@ func compareCPU(stats *v1alpha1.CPUStats, internal *CPUStats) error {
 	if internal.Time != stats.Time {
 		return fmt.Errorf(".Time")
 	}
-	if *internal.UsageNanoCores != *stats.UsageNanoCores {
-		return fmt.Errorf(".UsageNanoCores")
+	if *internal.UsageCoreNanoSeconds != *stats.UsageCoreNanoSeconds {
+		return fmt.Errorf(".UsageCoreNanoSeconds")
 	}
 	return nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -171,5 +171,10 @@ func (s *server) CheckReadiness(_ *http.Request) error {
 	if !tickLastOK {
 		return fmt.Errorf("last tick wasn't healthy")
 	}
+
+	if !s.storage.Ready() {
+		return fmt.Errorf("metrics-server needs at least 2 scrapes to serve metrics")
+	}
+
 	return nil
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -131,3 +131,7 @@ func (s *storageMock) GetContainerMetrics(pods ...apitypes.NamespacedName) ([]ap
 func (s *storageMock) GetNodeMetrics(nodes ...string) ([]api.TimeInfo, []corev1.ResourceList, error) {
 	return nil, nil, nil
 }
+
+func (s *storageMock) Ready() bool {
+	return true
+}

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -19,4 +19,5 @@ import "sigs.k8s.io/metrics-server/pkg/api"
 type Storage interface {
 	api.MetricsGetter
 	Store(batch *MetricsBatch)
+	Ready() bool
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -44,21 +44,16 @@ func NewStorage() *storage {
 }
 
 // Ready returns true if metrics-server's storage has accumulated enough metric
-// points to be able to serve NodeMetrics and PodMetrics.
+// points to serve NodeMetrics.
+// Checking only nodes for metrics-server's storage readiness is enough to make
+// sure that it has accumulated enough metrics to serve both NodeMetrics and
+// PodMetrics. It also covers cases where metrics-server only has to serve
+// NodeMetrics.
 func (p *storage) Ready() bool {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
-	if len(p.prevNodes) == 0 {
-		return false
-	}
-
-	for podIdent := range p.prevPods {
-		if len(p.prevPods[podIdent]) != 0 {
-			return true
-		}
-	}
-	return false
+	return len(p.prevNodes) != 0
 }
 
 func (p *storage) GetNodeMetrics(nodes ...string) ([]api.TimeInfo, []corev1.ResourceList, error) {

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -219,7 +219,7 @@ var _ = Describe("In-memory storage", func() {
 		Expect(ts).To(ConsistOf(api.TimeInfo{Timestamp: now.Add(400 * time.Millisecond), Window: 10 * time.Second}))
 
 		By("verifying that all containers have data")
-		Expect(containerMetrics).To(Equal(
+		Expect(containerMetrics).To(BeEquivalentTo(
 			[][]metrics.ContainerMetrics{
 				{
 					{
@@ -259,7 +259,7 @@ var _ = Describe("In-memory storage", func() {
 		Expect(ts).To(Equal([]api.TimeInfo{{Timestamp: now.Add(400 * time.Millisecond), Window: 10 * time.Second}, {}}))
 
 		By("verifying that all present containers have data")
-		Expect(containerMetrics).To(Equal(
+		Expect(containerMetrics).To(BeEquivalentTo(
 			[][]metrics.ContainerMetrics{
 				{
 					{
@@ -344,7 +344,7 @@ var _ = Describe("In-memory storage", func() {
 		Expect(ts).To(Equal([]api.TimeInfo{{}, {Timestamp: now.Add(600 * time.Millisecond), Window: 10 * time.Second}}))
 
 		By("verifying that all present nodes have data except the one with 2 similar metric points")
-		Expect(containerMetrics).To(Equal(
+		Expect(containerMetrics).To(BeEquivalentTo(
 			[][]metrics.ContainerMetrics{
 				nil,
 				{
@@ -372,7 +372,7 @@ var _ = Describe("In-memory storage", func() {
 		Expect(ts).To(Equal([]api.TimeInfo{{Timestamp: now.Add(100 * time.Millisecond), Window: 10 * time.Second}, {Timestamp: now.Add(200 * time.Millisecond), Window: 10 * time.Second}}))
 
 		By("verifying that all nodes have data")
-		Expect(nodeMetrics).To(Equal(
+		Expect(nodeMetrics).To(BeEquivalentTo(
 			[]corev1.ResourceList{
 				{
 					corev1.ResourceCPU:    *resource.NewScaledQuantity(10, -9),
@@ -398,7 +398,7 @@ var _ = Describe("In-memory storage", func() {
 		Expect(ts).To(Equal([]api.TimeInfo{{Timestamp: now.Add(100 * time.Millisecond), Window: 10 * time.Second}, {Timestamp: now.Add(200 * time.Millisecond), Window: 10 * time.Second}, {}}))
 
 		By("verifying that all present nodes have data")
-		Expect(nodeMetrics).To(Equal(
+		Expect(nodeMetrics).To(BeEquivalentTo(
 			[]corev1.ResourceList{
 				{
 					corev1.ResourceCPU:    *resource.NewScaledQuantity(10, -9),
@@ -470,7 +470,7 @@ var _ = Describe("In-memory storage", func() {
 		Expect(ts).To(Equal([]api.TimeInfo{{}, {Timestamp: now.Add(200 * time.Millisecond), Window: 10 * time.Second}}))
 
 		By("verifying that all present nodes have data except the one with 2 similar metric points")
-		Expect(nodeMetrics).To(Equal(
+		Expect(nodeMetrics).To(BeEquivalentTo(
 			[]corev1.ResourceList{
 				nil,
 				{

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -30,8 +30,6 @@ import (
 	"sigs.k8s.io/metrics-server/pkg/api"
 )
 
-var defaultWindow = 30 * time.Second
-
 func TestStorage(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "storage Suite")
@@ -217,7 +215,7 @@ var _ = Describe("In-memory storage", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("verifying that the timestamp is the smallest time amongst all containers")
-		Expect(ts).To(ConsistOf(api.TimeInfo{Timestamp: now.Add(400 * time.Millisecond), Window: defaultWindow}))
+		Expect(ts).To(ConsistOf(api.TimeInfo{Timestamp: now.Add(400 * time.Millisecond), Window: 10 * time.Second}))
 
 		By("verifying that all containers have data")
 		Expect(containerMetrics).To(Equal(
@@ -257,7 +255,7 @@ var _ = Describe("In-memory storage", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("verifying that the timestamp is the smallest time amongst all containers")
-		Expect(ts).To(Equal([]api.TimeInfo{{Timestamp: now.Add(400 * time.Millisecond), Window: defaultWindow}, {}}))
+		Expect(ts).To(Equal([]api.TimeInfo{{Timestamp: now.Add(400 * time.Millisecond), Window: 10 * time.Second}, {}}))
 
 		By("verifying that all present containers have data")
 		Expect(containerMetrics).To(Equal(
@@ -293,7 +291,7 @@ var _ = Describe("In-memory storage", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("verifying that the timestamp is the smallest time amongst all containers")
-		Expect(ts).To(Equal([]api.TimeInfo{{Timestamp: now.Add(100 * time.Millisecond), Window: defaultWindow}, {Timestamp: now.Add(200 * time.Millisecond), Window: defaultWindow}}))
+		Expect(ts).To(Equal([]api.TimeInfo{{Timestamp: now.Add(100 * time.Millisecond), Window: 10 * time.Second}, {Timestamp: now.Add(200 * time.Millisecond), Window: 10 * time.Second}}))
 
 		By("verifying that all nodes have data")
 		Expect(nodeMetrics).To(Equal(
@@ -319,7 +317,7 @@ var _ = Describe("In-memory storage", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("verifying that the timestamp is the smallest time amongst all containers")
-		Expect(ts).To(Equal([]api.TimeInfo{{Timestamp: now.Add(100 * time.Millisecond), Window: defaultWindow}, {Timestamp: now.Add(200 * time.Millisecond), Window: defaultWindow}, {}}))
+		Expect(ts).To(Equal([]api.TimeInfo{{Timestamp: now.Add(100 * time.Millisecond), Window: 10 * time.Second}, {Timestamp: now.Add(200 * time.Millisecond), Window: 10 * time.Second}, {}}))
 
 		By("verifying that all present nodes have data")
 		Expect(nodeMetrics).To(Equal(


### PR DESCRIPTION
**What this PR does / why we need it**:

As metrics-server will migrate to the new kubelet prometheus endpoint
using cumulative metrics, it should be ok to use usageCoreNanoSeconds
instead of usageNanoCores from the Summary API.

Metrics-server storage needed a rewrite in order to transform the
cumulative CPU usage metrics scraped from CAdvisor as an average usage
over a time window.
Instead of storing only the latest metric point of each resource,
metrics-server now also stores the previous one, to be able to compute
the CPU usage during the last time interval.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #567

