### PR TITLE
Increase image push timeout to 30 minutes

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 1200s
+timeout: 1800s
 options:
   substitution_option: ALLOW_LOOSE
 steps:


### PR DESCRIPTION

 Based on run for v0.4.2 timing out
/cc @s-urbaniak 