### PR TITLE
Use json6902 patch to inject --kubelet-insecure-tls flag

### DIFF
--- a/manifests/test/kustomization.yaml
+++ b/manifests/test/kustomization.yaml
@@ -2,8 +2,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
   - ../base
-patchesStrategicMerge:
-  - patch.yaml
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: metrics-server
+    namespace: kube-system
+  path: patch.yaml
 images:
   - name: gcr.io/k8s-staging-metrics-server/metrics-server
 

--- a/manifests/test/patch.yaml
+++ b/manifests/test/patch.yaml
@@ -1,18 +1,6 @@
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: metrics-server
-  namespace: kube-system
-spec:
-  template:
-    spec:
-      containers:
-        - name: metrics-server
-          imagePullPolicy: Never
-          args:
-          - --cert-dir=/tmp
-          - --secure-port=4443
-          - --kubelet-preferred-address-types=InternalIP
-          - --kubelet-insecure-tls
-          - --metric-resolution=15s
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --kubelet-insecure-tls
+- op: add
+  path: /spec/template/spec/containers/0/imagePullPolicy
+  value: Never


### PR DESCRIPTION
Normal patch cannot just add new element to list, meaning it requires
duplicating the list. Removing this duplication will reduce chance of args
going out of sync.
