### PR TITLE
Increase image build timeout to 1 hour

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 1800s
+timeout: 3600s
 options:
   substitution_option: ALLOW_LOOSE
 steps:


### PR DESCRIPTION
When trying to release 0.4.3 image build job timed ut. 