### PR TITLE
Increase image build timeout to 1 hour

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 1200s
+timeout: 3600s
 options:
   substitution_option: ALLOW_LOOSE
 steps:


### PR DESCRIPTION
Cherry-pick of https://github.com/kubernetes-sigs/metrics-server/pull/707 to release-0.4