### PR TITLE
Allow Metrics Server to listen on privileged ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ARG GIT_COMMIT
 ARG GIT_TAG
 ARG BUILD_DATE
 RUN make metrics-server
+RUN setcap cap_net_bind_service=+ep metrics-server
 
 FROM gcr.io/distroless/static:latest
 COPY --from=build /go/src/sigs.k8s.io/metrics-server/metrics-server /

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ pkg/scraper/types_easyjson.go: pkg/scraper/types.go
 container: container-$(ARCH)
 
 container-%: $(src_deps)
-	docker build --pull -t $(REGISTRY)/metrics-server-$*:$(GIT_COMMIT) --build-arg ARCH=$* --build-arg GIT_TAG=$(GIT_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg BUILD_DATE .
+	docker buildx build --pull -t $(REGISTRY)/metrics-server-$*:$(GIT_COMMIT) --build-arg ARCH=$* --build-arg GIT_TAG=$(GIT_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg BUILD_DATE .
 
 # Official Container Push Rules
 # -----------------------------


### PR DESCRIPTION
This requires switching to docker buildx, since COPY --from doesn't
preserve xattrs on standard docker build.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Cherrypick of #726 into 0.4 branch, to allow port 443 to be used.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: n/a


