### PR TITLE
Fix e2e failed with error ertificates 

### DIFF
--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -317,6 +317,7 @@ func sendRequest(config *rest.Config, url string) (*http.Response, error) {
 	}
 	tsConfig.TLS.Insecure = true
 	tsConfig.TLS.CAData = []byte{}
+	tsConfig.TLS.CAFile = ""
 
 	ts, err := transport.New(tsConfig)
 	if err != nil {


### PR DESCRIPTION
Fix e2e failed with error specifying a root certificates file with the insecure flag is not allowed

Signed-off-by: JunYang <yang.jun22@zte.com.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fix e2e failed with error specifying a root certificates file with the insecure flag is not allowed
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

