### PR TITLE
Metrics Server reports negative CPU usage for restarting pods

### DIFF
--- a/pkg/scraper/decode.go
+++ b/pkg/scraper/decode.go
@@ -66,6 +66,7 @@ func decodeNodeStats(nodeStats *NodeStats, target *storage.NodeMetricsPoint) (su
 	*target = storage.NodeMetricsPoint{
 		Name: nodeStats.NodeName,
 		MetricsPoint: storage.MetricsPoint{
+			StartTime: nodeStats.StartTime.Time,
 			Timestamp: timestamp,
 		},
 	}
@@ -100,6 +101,7 @@ func decodePodStats(podStats *PodStats, target *storage.PodMetricsPoint) (succes
 		point := storage.ContainerMetricsPoint{
 			Name: container.Name,
 			MetricsPoint: storage.MetricsPoint{
+				StartTime: container.StartTime.Time,
 				Timestamp: timestamp,
 			},
 		}

--- a/pkg/scraper/types.go
+++ b/pkg/scraper/types.go
@@ -30,6 +30,8 @@ type Summary struct {
 type NodeStats struct {
 	// Reference to the measured Node.
 	NodeName string `json:"nodeName"`
+	// Start time of system
+	StartTime metav1.Time `json:"startTime"`
 	// Stats pertaining to CPU resources.
 	// +optional
 	CPU *CPUStats `json:"cpu,omitempty"`
@@ -52,6 +54,8 @@ type PodStats struct {
 type ContainerStats struct {
 	// Reference to the measured container.
 	Name string `json:"name"`
+	// Start time of container
+	StartTime metav1.Time `json:"startTime"`
 	// Stats pertaining to CPU resources.
 	// +optional
 	CPU *CPUStats `json:"cpu,omitempty"`

--- a/pkg/scraper/types_easyjson.go
+++ b/pkg/scraper/types_easyjson.go
@@ -151,7 +151,7 @@ func easyjson6601e8cdDecodeSigsK8sIoMetricsServerPkgScraper1(in *jlexer.Lexer, o
 				in.Delim('[')
 				if out.Containers == nil {
 					if !in.IsDelim(']') {
-						out.Containers = make([]ContainerStats, 0, 2)
+						out.Containers = make([]ContainerStats, 0, 1)
 					} else {
 						out.Containers = []ContainerStats{}
 					}
@@ -321,6 +321,10 @@ func easyjson6601e8cdDecodeSigsK8sIoMetricsServerPkgScraper3(in *jlexer.Lexer, o
 		switch key {
 		case "nodeName":
 			out.NodeName = string(in.String())
+		case "startTime":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.StartTime).UnmarshalJSON(data))
+			}
 		case "cpu":
 			if in.IsNull() {
 				in.Skip()
@@ -359,6 +363,11 @@ func easyjson6601e8cdEncodeSigsK8sIoMetricsServerPkgScraper3(out *jwriter.Writer
 		const prefix string = ",\"nodeName\":"
 		out.RawString(prefix[1:])
 		out.String(string(in.NodeName))
+	}
+	{
+		const prefix string = ",\"startTime\":"
+		out.RawString(prefix)
+		out.Raw((in.StartTime).MarshalJSON())
 	}
 	if in.CPU != nil {
 		const prefix string = ",\"cpu\":"
@@ -500,6 +509,10 @@ func easyjson6601e8cdDecodeSigsK8sIoMetricsServerPkgScraper5(in *jlexer.Lexer, o
 		switch key {
 		case "name":
 			out.Name = string(in.String())
+		case "startTime":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.StartTime).UnmarshalJSON(data))
+			}
 		case "cpu":
 			if in.IsNull() {
 				in.Skip()
@@ -538,6 +551,11 @@ func easyjson6601e8cdEncodeSigsK8sIoMetricsServerPkgScraper5(out *jwriter.Writer
 		const prefix string = ",\"name\":"
 		out.RawString(prefix[1:])
 		out.String(string(in.Name))
+	}
+	{
+		const prefix string = ",\"startTime\":"
+		out.RawString(prefix)
+		out.Raw((in.StartTime).MarshalJSON())
 	}
 	if in.CPU != nil {
 		const prefix string = ",\"cpu\":"

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-base/metrics/testutil"
-	metrics "k8s.io/metrics/pkg/apis/metrics"
+	"k8s.io/metrics/pkg/apis/metrics"
 
 	"sigs.k8s.io/metrics-server/pkg/api"
 )
@@ -36,8 +36,9 @@ func TestStorage(t *testing.T) {
 	RunSpecs(t, "storage Suite")
 }
 
-func newMetricsPoint(ts time.Time, cpu, memory int64) MetricsPoint {
+func newMetricsPoint(st time.Time, ts time.Time, cpu, memory int64) MetricsPoint {
 	return MetricsPoint{
+		StartTime:   st,
 		Timestamp:   ts,
 		CpuUsage:    *resource.NewScaledQuantity(cpu, -9),
 		MemoryUsage: *resource.NewMilliQuantity(memory, resource.BinarySI),
@@ -57,41 +58,41 @@ var _ = Describe("In-memory storage", func() {
 		prevTS := now.Add(-10 * time.Second)
 		prevBatch = &MetricsBatch{
 			Nodes: []NodeMetricsPoint{
-				{Name: "node1", MetricsPoint: newMetricsPoint(prevTS.Add(100*time.Millisecond), 10, 120)},
-				{Name: "node2", MetricsPoint: newMetricsPoint(prevTS.Add(200*time.Millisecond), 110, 220)},
-				{Name: "node3", MetricsPoint: newMetricsPoint(prevTS.Add(300*time.Millisecond), 210, 320)},
+				{Name: "node1", MetricsPoint: newMetricsPoint(prevTS, prevTS.Add(100*time.Millisecond), 10, 120)},
+				{Name: "node2", MetricsPoint: newMetricsPoint(prevTS, prevTS.Add(200*time.Millisecond), 110, 220)},
+				{Name: "node3", MetricsPoint: newMetricsPoint(prevTS, prevTS.Add(300*time.Millisecond), 210, 320)},
 			},
 			Pods: []PodMetricsPoint{
 				{Name: "pod1", Namespace: "ns1", Containers: []ContainerMetricsPoint{
-					{Name: "container1", MetricsPoint: newMetricsPoint(prevTS.Add(400*time.Millisecond), 310, 420)},
-					{Name: "container2", MetricsPoint: newMetricsPoint(prevTS.Add(500*time.Millisecond), 410, 520)},
+					{Name: "container1", MetricsPoint: newMetricsPoint(prevTS, prevTS.Add(400*time.Millisecond), 310, 420)},
+					{Name: "container2", MetricsPoint: newMetricsPoint(prevTS, prevTS.Add(500*time.Millisecond), 410, 520)},
 				}},
 				{Name: "pod2", Namespace: "ns1", Containers: []ContainerMetricsPoint{
-					{Name: "container1", MetricsPoint: newMetricsPoint(prevTS.Add(600*time.Millisecond), 510, 620)},
+					{Name: "container1", MetricsPoint: newMetricsPoint(prevTS, prevTS.Add(600*time.Millisecond), 510, 620)},
 				}},
 				{Name: "pod1", Namespace: "ns2", Containers: []ContainerMetricsPoint{
-					{Name: "container1", MetricsPoint: newMetricsPoint(prevTS.Add(700*time.Millisecond), 610, 720)},
-					{Name: "container2", MetricsPoint: newMetricsPoint(prevTS.Add(800*time.Millisecond), 710, 820)},
+					{Name: "container1", MetricsPoint: newMetricsPoint(prevTS, prevTS.Add(700*time.Millisecond), 610, 720)},
+					{Name: "container2", MetricsPoint: newMetricsPoint(prevTS, prevTS.Add(800*time.Millisecond), 710, 820)},
 				}},
 			},
 		}
 		batch = &MetricsBatch{
 			Nodes: []NodeMetricsPoint{
-				{Name: "node1", MetricsPoint: newMetricsPoint(now.Add(100*time.Millisecond), 110, 120)},
-				{Name: "node2", MetricsPoint: newMetricsPoint(now.Add(200*time.Millisecond), 210, 220)},
-				{Name: "node3", MetricsPoint: newMetricsPoint(now.Add(300*time.Millisecond), 310, 320)},
+				{Name: "node1", MetricsPoint: newMetricsPoint(prevTS, now.Add(100*time.Millisecond), 110, 120)},
+				{Name: "node2", MetricsPoint: newMetricsPoint(prevTS, now.Add(200*time.Millisecond), 210, 220)},
+				{Name: "node3", MetricsPoint: newMetricsPoint(prevTS, now.Add(300*time.Millisecond), 310, 320)},
 			},
 			Pods: []PodMetricsPoint{
 				{Name: "pod1", Namespace: "ns1", Containers: []ContainerMetricsPoint{
-					{Name: "container1", MetricsPoint: newMetricsPoint(now.Add(400*time.Millisecond), 410, 420)},
-					{Name: "container2", MetricsPoint: newMetricsPoint(now.Add(500*time.Millisecond), 510, 520)},
+					{Name: "container1", MetricsPoint: newMetricsPoint(prevTS, now.Add(400*time.Millisecond), 410, 420)},
+					{Name: "container2", MetricsPoint: newMetricsPoint(prevTS, now.Add(500*time.Millisecond), 510, 520)},
 				}},
 				{Name: "pod2", Namespace: "ns1", Containers: []ContainerMetricsPoint{
-					{Name: "container1", MetricsPoint: newMetricsPoint(now.Add(600*time.Millisecond), 610, 620)},
+					{Name: "container1", MetricsPoint: newMetricsPoint(prevTS, now.Add(600*time.Millisecond), 610, 620)},
 				}},
 				{Name: "pod1", Namespace: "ns2", Containers: []ContainerMetricsPoint{
-					{Name: "container1", MetricsPoint: newMetricsPoint(now.Add(700*time.Millisecond), 710, 720)},
-					{Name: "container2", MetricsPoint: newMetricsPoint(now.Add(800*time.Millisecond), 810, 820)},
+					{Name: "container1", MetricsPoint: newMetricsPoint(prevTS, now.Add(700*time.Millisecond), 710, 720)},
+					{Name: "container2", MetricsPoint: newMetricsPoint(prevTS, now.Add(800*time.Millisecond), 810, 820)},
 				}},
 			},
 		}
@@ -287,7 +288,7 @@ var _ = Describe("In-memory storage", func() {
 
 	It("should return nil metrics when a pod was added in the last scrape", func() {
 		newPodPoint := PodMetricsPoint{Name: "pod2", Namespace: "ns2", Containers: []ContainerMetricsPoint{
-			{Name: "container1", MetricsPoint: newMetricsPoint(now.Add(900*time.Millisecond), 910, 920)},
+			{Name: "container1", MetricsPoint: newMetricsPoint(now, now.Add(900*time.Millisecond), 910, 920)},
 		}}
 
 		By("adding a new pod to the batch")
@@ -418,7 +419,7 @@ var _ = Describe("In-memory storage", func() {
 
 	It("should return nil metrics when a node was added in the last scrape", func() {
 		newNodePoint := NodeMetricsPoint{
-			Name: "node4", MetricsPoint: newMetricsPoint(now.Add(400*time.Millisecond), 410, 520),
+			Name: "node4", MetricsPoint: newMetricsPoint(now, now.Add(400*time.Millisecond), 410, 520),
 		}
 
 		By("adding a new node to the batch")
@@ -497,6 +498,33 @@ var _ = Describe("In-memory storage", func() {
 		metrics_server_storage_points{type="container"} 5
 		`), "metrics_server_storage_points")
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should return nil metrics when a node restarted", func() {
+		batch.Nodes[0] = NodeMetricsPoint{Name: "node1", MetricsPoint: newMetricsPoint(now, now, 10, 120)}
+		storage.Store(batch)
+		_, nodeMetrics, err := storage.GetNodeMetrics("node1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodeMetrics[0]).To(BeNil())
+		_, nodeMetrics, err = storage.GetNodeMetrics("node2")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodeMetrics[0]).NotTo(BeNil())
+	})
+
+	It("should return nil metrics when a container restarted", func() {
+		batch.Pods[0].Containers[0] = ContainerMetricsPoint{Name: "container1", MetricsPoint: newMetricsPoint(now, now.Add(400*time.Millisecond), 310, 420)}
+		batch.Pods[0].Containers[1] = ContainerMetricsPoint{Name: "container2", MetricsPoint: newMetricsPoint(now, now.Add(500*time.Millisecond), 410, 520)}
+		storage.Store(batch)
+		_, containerMetrics, err := storage.GetContainerMetrics(
+			apitypes.NamespacedName{Name: "pod1", Namespace: "ns1"},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(containerMetrics[0]).To(BeNil())
+		_, containerMetrics, err = storage.GetContainerMetrics(
+			apitypes.NamespacedName{Name: "pod2", Namespace: "ns1"},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(containerMetrics[0]).NotTo(BeNil())
 	})
 })
 

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -48,6 +48,7 @@ type ContainerMetricsPoint struct {
 
 // MetricsPoint represents the a set of specific metrics at some point in time.
 type MetricsPoint struct {
+	StartTime time.Time
 	Timestamp time.Time
 	// CpuUsage is the CPU usage rate, in cores
 	CpuUsage resource.Quantity


### PR DESCRIPTION
Signed-off-by: JunYang <yang.jun22@zte.com.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Metrics Server reports negative CPU usage for restarting pods
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #745 

