### PR TITLE
Depend on CPU.Time and StartTime when decoding metrics

### DIFF
--- a/pkg/scraper/scraper_test.go
+++ b/pkg/scraper/scraper_test.go
@@ -39,11 +39,12 @@ func TestScraper(t *testing.T) {
 	RunSpecs(t, "Scraper Suite")
 }
 
-func nodeStats(node *corev1.Node, cpu, memory int, scrapeTime time.Time) NodeStats {
+func nodeStats(node *corev1.Node, cpu, memory int, startTime time.Time) NodeStats {
 	return NodeStats{
-		NodeName: node.Name,
-		CPU:      cpuStats(100, scrapeTime.Add(100*time.Millisecond)),
-		Memory:   memStats(200, scrapeTime.Add(200*time.Millisecond)),
+		NodeName:  node.Name,
+		CPU:       cpuStats(100, startTime.Add(100*time.Millisecond)),
+		Memory:    memStats(200, startTime.Add(200*time.Millisecond)),
+		StartTime: metav1.Time{Time: startTime},
 	}
 }
 


### PR DESCRIPTION
* Since switching to cumulative metric we should not depend on memory
metric time as we use it to calculate CPU uage as differential.
* As start time is used to detect container restarts we need to make
sure it required

/cc @dgrisonnet @yangjunmyfm192085 
