### PR TITLE
Rename storage fields and comment

### DIFF
--- a/pkg/scraper/client/summary/decode.go
+++ b/pkg/scraper/client/summary/decode.go
@@ -69,7 +69,7 @@ func decodeNodeStats(nodeStats *NodeStats, target *storage.NodeMetricsPoint) (su
 		},
 	}
 	success = true
-	if err := decodeCPU(&target.CpuUsage, nodeStats.CPU); err != nil {
+	if err := decodeCPU(&target.CumulativeCpuUsed, nodeStats.CPU); err != nil {
 		klog.V(1).InfoS("Skipped node CPU metric", "node", klog.KRef("", nodeStats.NodeName), "err", err)
 		success = false
 	}
@@ -103,7 +103,7 @@ func decodePodStats(podStats *PodStats, target *storage.PodMetricsPoint) (succes
 				Timestamp: container.CPU.Time.Time,
 			},
 		}
-		if err := decodeCPU(&point.CpuUsage, container.CPU); err != nil {
+		if err := decodeCPU(&point.CumulativeCpuUsed, container.CPU); err != nil {
 			klog.V(1).InfoS("Skipped container CPU metric", "containerName", container.Name, "pod", klog.KRef(target.Namespace, target.Name), "err", err)
 			success = false
 		}

--- a/pkg/scraper/client/summary/decode_test.go
+++ b/pkg/scraper/client/summary/decode_test.go
@@ -119,8 +119,8 @@ var _ = Describe("Decode", func() {
 		podMem := *resource.NewScaledQuantity(int64(minusOneHundred/10), 1)
 		podMem.Format = resource.BinarySI
 		Expect(batch.Nodes[0].MemoryUsage).To(Equal(nodeMem))
-		Expect(batch.Nodes[0].CpuUsage).To(Equal(*resource.NewScaledQuantity(int64(plusTwenty/10), -8)))
-		Expect(batch.Pods[0].Containers[1].CpuUsage).To(Equal(*resource.NewScaledQuantity(int64(minusTen/10), -8)))
+		Expect(batch.Nodes[0].CumulativeCpuUsed).To(Equal(*resource.NewScaledQuantity(int64(plusTwenty/10), -8)))
+		Expect(batch.Pods[0].Containers[1].CumulativeCpuUsed).To(Equal(*resource.NewScaledQuantity(int64(minusTen/10), -8)))
 		Expect(batch.Pods[1].Containers[0].MemoryUsage).To(Equal(podMem))
 	})
 })

--- a/pkg/scraper/client/summary/types_test.go
+++ b/pkg/scraper/client/summary/types_test.go
@@ -336,9 +336,9 @@ var expected = &storage.MetricsBatch{
 		{
 			Name: "e2e-v1.17.0-control-plane",
 			MetricsPoint: storage.MetricsPoint{
-				Timestamp:   time.Date(2020, 4, 16, 22, 25, 28, 0, time.Local),
-				CpuUsage:    *resource.NewScaledQuantity(476553087, -9),
-				MemoryUsage: *resource.NewQuantity(1417551872, resource.BinarySI),
+				Timestamp:         time.Date(2020, 4, 16, 22, 25, 28, 0, time.Local),
+				CumulativeCpuUsed: *resource.NewScaledQuantity(476553087, -9),
+				MemoryUsage:       *resource.NewQuantity(1417551872, resource.BinarySI),
 			},
 		},
 	},
@@ -350,9 +350,9 @@ var expected = &storage.MetricsBatch{
 				{
 					Name: "load",
 					MetricsPoint: storage.MetricsPoint{
-						Timestamp:   time.Date(2020, 4, 16, 22, 25, 30, 0, time.Local),
-						CpuUsage:    *resource.NewScaledQuantity(29713960, -9),
-						MemoryUsage: *resource.NewQuantity(1449984, resource.BinarySI),
+						Timestamp:         time.Date(2020, 4, 16, 22, 25, 30, 0, time.Local),
+						CumulativeCpuUsed: *resource.NewScaledQuantity(29713960, -9),
+						MemoryUsage:       *resource.NewQuantity(1449984, resource.BinarySI),
 					},
 				},
 			},

--- a/pkg/scraper/scraper_test.go
+++ b/pkg/scraper/scraper_test.go
@@ -221,18 +221,18 @@ func nodeMetrics(node *corev1.Node, cpu, memory int64, scrapeTime time.Time) sto
 	return storage.NodeMetricsPoint{
 		Name: node.Name,
 		MetricsPoint: storage.MetricsPoint{
-			CpuUsage:    *resource.NewScaledQuantity(cpu, -9),
-			MemoryUsage: *resource.NewScaledQuantity(memory, 0),
-			Timestamp:   scrapeTime,
+			CumulativeCpuUsed: *resource.NewScaledQuantity(cpu, -9),
+			MemoryUsage:       *resource.NewScaledQuantity(memory, 0),
+			Timestamp:         scrapeTime,
 		},
 	}
 }
 
 func metricPoint(cpu, memory int64, time time.Time) storage.MetricsPoint {
 	return storage.MetricsPoint{
-		Timestamp:   time,
-		CpuUsage:    *resource.NewScaledQuantity(cpu, -9),
-		MemoryUsage: *resource.NewScaledQuantity(memory, 0),
+		Timestamp:         time,
+		CumulativeCpuUsed: *resource.NewScaledQuantity(cpu, -9),
+		MemoryUsage:       *resource.NewScaledQuantity(memory, 0),
 	}
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -54,9 +54,9 @@ var _ = Describe("Server", func() {
 					{
 						Name: "node1",
 						MetricsPoint: storage.MetricsPoint{
-							Timestamp:   time.Now(),
-							CpuUsage:    resource.Quantity{},
-							MemoryUsage: resource.Quantity{},
+							Timestamp:         time.Now(),
+							CumulativeCpuUsed: resource.Quantity{},
+							MemoryUsage:       resource.Quantity{},
 						},
 					},
 				},

--- a/pkg/storage/storage_benchmark_test.go
+++ b/pkg/storage/storage_benchmark_test.go
@@ -360,9 +360,9 @@ func (g *generator) RandomString(length int) string {
 
 func (g *generator) RandomMetricsPoint() MetricsPoint {
 	return MetricsPoint{
-		Timestamp:   time.Now(),
-		CpuUsage:    *resource.NewQuantity(g.rand.Int63(), resource.BinarySI),
-		MemoryUsage: *resource.NewQuantity(g.rand.Int63(), resource.BinarySI),
+		Timestamp:         time.Now(),
+		CumulativeCpuUsed: *resource.NewQuantity(g.rand.Int63(), resource.BinarySI),
+		MemoryUsage:       *resource.NewQuantity(g.rand.Int63(), resource.BinarySI),
 	}
 }
 

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -38,10 +38,10 @@ func TestStorage(t *testing.T) {
 
 func newMetricsPoint(st time.Time, ts time.Time, cpu, memory int64) MetricsPoint {
 	return MetricsPoint{
-		StartTime:   st,
-		Timestamp:   ts,
-		CpuUsage:    *resource.NewScaledQuantity(cpu, -9),
-		MemoryUsage: *resource.NewMilliQuantity(memory, resource.BinarySI),
+		StartTime:         st,
+		Timestamp:         ts,
+		CumulativeCpuUsed: *resource.NewScaledQuantity(cpu, -9),
+		MemoryUsage:       *resource.NewMilliQuantity(memory, resource.BinarySI),
 	}
 }
 

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -48,10 +48,12 @@ type ContainerMetricsPoint struct {
 
 // MetricsPoint represents the a set of specific metrics at some point in time.
 type MetricsPoint struct {
+	// StartTime is the start time of container/node. Cumulative CPU usage at that moment should be equal zero.
 	StartTime time.Time
+	// Timestamp is the time when metric point was measured. If CPU and Memory was measured at different time it should equal CPU time to allow accurate CPU calculation.
 	Timestamp time.Time
-	// CpuUsage is the CPU usage rate, in cores
-	CpuUsage resource.Quantity
-	// MemoryUsage is the working set size, in bytes.
+	// CumulativeCpuUsed is the cumulative cpu used at Timestamp from the StartTime of container/node. Unit: core * seconds.
+	CumulativeCpuUsed resource.Quantity
+	// MemoryUsage is the working set size. Unit: bytes.
 	MemoryUsage resource.Quantity
 }


### PR DESCRIPTION
To make reading storage code for new contributors easier I'm introducing
naming convention:
* last - stored in last scrape
* previous - stored in scrape preceding last scrape
* new - currently being introduced to storage

/cc @dgrisonnet 
