### PR TITLE
Skip metric point if usageCoreNanoSeconds or workingSetBytes is zero

### DIFF
--- a/pkg/scraper/client/summary/decode.go
+++ b/pkg/scraper/client/summary/decode.go
@@ -122,6 +122,9 @@ func decodeCPU(target *resource.Quantity, cpuStats *CPUStats) error {
 		return fmt.Errorf("missing usageCoreNanoSeconds value")
 	}
 
+	if *cpuStats.UsageCoreNanoSeconds == 0 {
+		return fmt.Errorf("Got UsageCoreNanoSeconds equal zero")
+	}
 	*target = *uint64Quantity(*cpuStats.UsageCoreNanoSeconds, -9)
 	return nil
 }
@@ -129,6 +132,9 @@ func decodeCPU(target *resource.Quantity, cpuStats *CPUStats) error {
 func decodeMemory(target *resource.Quantity, memStats *MemoryStats) error {
 	if memStats == nil || memStats.WorkingSetBytes == nil {
 		return fmt.Errorf("missing workingSetBytes value")
+	}
+	if *memStats.WorkingSetBytes == 0 {
+		return fmt.Errorf("Got WorkingSetBytes equal zero")
 	}
 
 	*target = *uint64Quantity(*memStats.WorkingSetBytes, 0)

--- a/pkg/scraper/client/summary/decode_test.go
+++ b/pkg/scraper/client/summary/decode_test.go
@@ -123,6 +123,20 @@ var _ = Describe("Decode", func() {
 		Expect(batch.Pods[0].Containers[1].CumulativeCpuUsed).To(Equal(*resource.NewScaledQuantity(int64(minusTen/10), -8)))
 		Expect(batch.Pods[1].Containers[0].MemoryUsage).To(Equal(podMem))
 	})
+
+	It("should skip on cumulative CPU equal zero", func() {
+		By("setting CPU cumulative value to zero")
+		var zero uint64 = 0
+		summary.Node.CPU.UsageCoreNanoSeconds = &zero
+		summary.Pods[0].Containers[0].CPU.UsageCoreNanoSeconds = &zero
+
+		By("decoding")
+		batch := decodeBatch(summary)
+
+		By("verifying that zero records were deleted")
+		Expect(batch.Pods).To(HaveLen(3))
+		Expect(batch.Nodes).To(HaveLen(0))
+	})
 })
 
 func cpuStats(usageCoreNanoSeconds uint64, ts time.Time) *CPUStats {


### PR DESCRIPTION
Noticed new cases where MS can return negative value due to storing 0 metric value.
Started testing decoding but at the end found out that summary api can return 0 in some cases.

It's pretty rare case so I needed to use script
```
while true; do kubectl get --raw /api/v1/nodes/kind-control-plane/proxy/stats/summary | jq '.pods[].containers[] | select(.cpu.usageCoreNanoSeconds==0) | {name: .name, startTime: .startTime, cpu: .cpu, memory: .memory}';sleep 1; done
```
Found out that if metric is scraped just after container process stops.
Example result:
```
{
  "name": "resource-consumer",
  "startTime": "2021-05-15T18:57:01Z",
  "cpu": {
    "time": "2021-05-15T18:57:36Z",
    "usageNanoCores": 99393378,
    "usageCoreNanoSeconds": 0
  },
  "memory": {
    "time": "2021-05-15T18:57:36Z",
    "workingSetBytes": 0
  }
}
```
As resource-consumer process is set to exit after 35s, this matches exact time from `startTime` to `time` in metric.