### PR TITLE
Utilize container start time to speed up returning metrics for fresh …

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -73,7 +73,7 @@ func (c Config) Complete() (*server, error) {
 	}
 	genericServer.Handler.NonGoRestfulMux.HandleFunc("/metrics", metricsHandler)
 
-	store := storage.NewStorage()
+	store := storage.NewStorage(c.MetricResolution)
 	if err := api.Install(store, &podMetadataLister{podInformer.Lister()}, nodes.Lister(), genericServer); err != nil {
 		return nil, err
 	}

--- a/pkg/storage/node_test.go
+++ b/pkg/storage/node_test.go
@@ -36,7 +36,7 @@ func TestNodeStorage(t *testing.T) {
 
 var _ = Describe("Node storage", func() {
 	It("provides node metrics from stored batches", func() {
-		s := NewStorage()
+		s := NewStorage(60 * time.Second)
 		nodeStart := time.Now()
 
 		By("storing first batch with node1 metrics")
@@ -72,7 +72,7 @@ var _ = Describe("Node storage", func() {
 		checkNodeResponseEmpty(s, "node1")
 	})
 	It("should handle duplicate node", func() {
-		s := NewStorage()
+		s := NewStorage(60 * time.Second)
 		nodeStart := time.Now()
 
 		By("store first batch")
@@ -102,7 +102,7 @@ var _ = Describe("Node storage", func() {
 		))
 	})
 	It("handle repeated node metric point", func() {
-		s := NewStorage()
+		s := NewStorage(60 * time.Second)
 		nodeStart := time.Now()
 
 		By("storing first batch with node1 metrics")
@@ -118,7 +118,7 @@ var _ = Describe("Node storage", func() {
 	It("exposes correct node metrics", func() {
 		pointsStored.Create(nil)
 		pointsStored.Reset()
-		s := NewStorage()
+		s := NewStorage(60 * time.Second)
 		nodeStart := time.Now()
 
 		err := testutil.CollectAndCompare(pointsStored, strings.NewReader(`
@@ -148,7 +148,7 @@ var _ = Describe("Node storage", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 	It("should detect node restart and skip metric", func() {
-		s := NewStorage()
+		s := NewStorage(60 * time.Second)
 		nodeStart := time.Now()
 
 		By("storing first batch with node1 metrics")
@@ -161,7 +161,7 @@ var _ = Describe("Node storage", func() {
 		checkNodeResponseEmpty(s, "node1")
 	})
 	It("should return empty node metrics if decreased data point reported", func() {
-		s := NewStorage()
+		s := NewStorage(60 * time.Second)
 		nodeStart := time.Now()
 
 		By("storing previous metrics")
@@ -174,7 +174,7 @@ var _ = Describe("Node storage", func() {
 		checkNodeResponseEmpty(s, "node1")
 	})
 	It("should handle metrics older then prev", func() {
-		s := NewStorage()
+		s := NewStorage(60 * time.Second)
 		nodeStart := time.Now()
 
 		By("storing previous metrics")
@@ -191,7 +191,7 @@ var _ = Describe("Node storage", func() {
 	})
 
 	It("should handle metrics prev.ts < newNode.ts < last.ts", func() {
-		s := NewStorage()
+		s := NewStorage(60 * time.Second)
 		nodeStart := time.Now()
 
 		By("storing previous metrics")

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -28,16 +28,15 @@ import (
 
 // nodeStorage is a thread save nodeStorage for node and pod metrics.
 type storage struct {
-	mu             sync.RWMutex
-	scrapeDuration time.Duration
-	pods           podStorage
-	nodes          nodeStorage
+	mu    sync.RWMutex
+	pods  podStorage
+	nodes nodeStorage
 }
 
 var _ Storage = (*storage)(nil)
 
-func NewStorage(scrapeDuration time.Duration) *storage {
-	return &storage{scrapeDuration: scrapeDuration}
+func NewStorage(metricResolution time.Duration) *storage {
+	return &storage{pods: podStorage{metricResolution: metricResolution}}
 }
 
 // Ready returns true if metrics-server's storage has accumulated enough metric
@@ -68,6 +67,5 @@ func (s *storage) Store(batch *MetricsBatch) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.nodes.Store(batch.Nodes)
-	s.pods.metricResolution = s.scrapeDuration
 	s.pods.Store(batch.Pods)
 }

--- a/pkg/storage/storage_benchmark_test.go
+++ b/pkg/storage/storage_benchmark_test.go
@@ -140,7 +140,7 @@ func BenchmarkStorageWrite(b *testing.B) {
 }
 
 func benchmarkStorageWrite(b *testing.B, g *generator) {
-	s := NewStorage()
+	s := NewStorage(60 * time.Second)
 	// Limit size to limit memory needed
 	maxSize := 100
 	if maxSize > b.N {
@@ -168,7 +168,7 @@ func BenchmarkStorageReadContainer(b *testing.B) {
 }
 
 func benchmarkStorageReadContainer(b *testing.B, g *generator) {
-	s := NewStorage()
+	s := NewStorage(60 * time.Second)
 	s.Store(g.NewBatch())
 	s.Store(g.NewBatch())
 	deployments := g.Deployments()
@@ -207,7 +207,7 @@ func BenchmarkStorageReadNode(b *testing.B) {
 }
 
 func benchmarkStorageReadNode(b *testing.B, g *generator) {
-	s := NewStorage()
+	s := NewStorage(60 * time.Second)
 	s.Store(g.NewBatch())
 	s.Store(g.NewBatch())
 	nodes := g.Nodes()


### PR DESCRIPTION
…containers

Signed-off-by: JunYang <yang.jun22@zte.com.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Utilize container start time to speed up returning metrics for fresh containers
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #747

