### PR TITLE
Improve reliability of probes

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -41,6 +41,7 @@ spec:
             scheme: HTTPS
           periodSeconds: 10
           failureThreshold: 3
+          initialDelaySeconds: 20
         livenessProbe:
           httpGet:
             path: /livez

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -24,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apimetrics "k8s.io/apiserver/pkg/endpoints/metrics"
 	genericapiserver "k8s.io/apiserver/pkg/server"
-	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/client-go/rest"
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
@@ -86,15 +85,7 @@ func (c Config) Complete() (*server, error) {
 		scrape,
 		c.MetricResolution,
 	)
-	err = s.AddReadyzChecks(healthz.NamedCheck("metric-collection-successful", s.ProbeMetricCollectionSuccessful))
-	if err != nil {
-		return nil, err
-	}
-	err = s.AddLivezChecks(0, healthz.NamedCheck("metric-collection-timely", s.ProbeMetricCollectionTimely))
-	if err != nil {
-		return nil, err
-	}
-	err = s.AddHealthChecks(MetadataInformerSyncHealthz(podInformerFactory))
+	err = s.RegisterProbes(podInformerFactory)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/health.go
+++ b/pkg/server/health.go
@@ -27,20 +27,22 @@ type cacheSyncWaiter interface {
 }
 
 type metadataInformerSync struct {
+	name            string
 	cacheSyncWaiter cacheSyncWaiter
 }
 
 var _ healthz.HealthChecker = &metadataInformerSync{}
 
 // MetadataInformerSyncHealthz returns a new HealthChecker that will pass only if all informers in the given cacheSyncWaiter sync.
-func MetadataInformerSyncHealthz(cacheSyncWaiter cacheSyncWaiter) healthz.HealthChecker {
+func MetadataInformerSyncHealthz(name string, cacheSyncWaiter cacheSyncWaiter) healthz.HealthChecker {
 	return &metadataInformerSync{
+		name:            name,
 		cacheSyncWaiter: cacheSyncWaiter,
 	}
 }
 
 func (i *metadataInformerSync) Name() string {
-	return "metadata-informer-sync"
+	return i.name
 }
 
 func (i *metadataInformerSync) Check(_ *http.Request) error {

--- a/pkg/storage/pod_test.go
+++ b/pkg/storage/pod_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Pod storage", func() {
 		s.Store(podMetricsBatch(podMetrics(podRef, ContainerMetricsPoint{"container1", newMetricsPoint(containerStart, containerStart.Add(125*time.Second), 6*CoreSecond, 5*MiByte)})))
 
 		By("returning metric for pod1")
-		Expect(s.Ready()).NotTo(BeTrue())
+		Expect(s.Ready()).To(BeTrue())
 		ts, ms, err := s.GetPodMetrics(podRef)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ts).Should(BeEquivalentTo([]api.TimeInfo{{Timestamp: containerStart.Add(125 * time.Second), Window: 5 * time.Second}}))
@@ -92,7 +92,7 @@ var _ = Describe("Pod storage", func() {
 		)))
 
 		By("returning correct metric values")
-		Expect(s.Ready()).NotTo(BeTrue())
+		Expect(s.Ready()).To(BeTrue())
 		ts, _, err := s.GetPodMetrics(podRef)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ts).Should(BeEquivalentTo([]api.TimeInfo{{Timestamp: containerStart.Add(120 * time.Second), Window: 10 * time.Second}}))
@@ -115,7 +115,7 @@ var _ = Describe("Pod storage", func() {
 		))
 
 		By("returning correct metric values")
-		Expect(s.Ready()).NotTo(BeTrue())
+		Expect(s.Ready()).To(BeTrue())
 		ts, ms, err := s.GetPodMetrics(podRef)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ts).Should(BeEquivalentTo([]api.TimeInfo{{Timestamp: containerStart.Add(115 * time.Second), Window: 5 * time.Second}}))
@@ -192,8 +192,7 @@ var _ = Describe("Pod storage", func() {
 		By("storing second batch with pod1 start time after previous batch")
 		s.Store(podMetricsBatch(podMetrics(podRef, ContainerMetricsPoint{"container1", newMetricsPoint(containerStart.Add(15*time.Second), containerStart.Add(20*time.Second), 5*CoreSecond, 5*MiByte)})))
 
-		By("return results based on window from start tim")
-		Expect(s.Ready()).NotTo(BeTrue())
+		By("return results based on window from start time")
 		ts, ms, err := s.GetPodMetrics(podRef)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ts).Should(BeEquivalentTo([]api.TimeInfo{{Timestamp: containerStart.Add(20 * time.Second), Window: 5 * time.Second}}))
@@ -283,7 +282,7 @@ var _ = Describe("Pod storage", func() {
 
 		By("storing first batch with pod1 metrics")
 		s.Store(podMetricsBatch(podMetrics(podRef, ContainerMetricsPoint{"container1", newMetricsPoint(containerStart, containerStart.Add(10*time.Second), 10*CoreSecond, 4*MiByte)})))
-		Expect(s.Ready()).NotTo(BeTrue())
+		Expect(s.Ready()).To(BeTrue())
 
 		ts, ms, err := s.GetPodMetrics(podRef)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -41,14 +41,10 @@ func NewStorage(metricResolution time.Duration) *storage {
 
 // Ready returns true if metrics-server's storage has accumulated enough metric
 // points to serve NodeMetrics.
-// Checking only nodes for metrics-server's storage readiness is enough to make
-// sure that it has accumulated enough metrics to serve both NodeMetrics and
-// PodMetrics. It also covers cases where metrics-server only has to serve
-// NodeMetrics.
 func (s *storage) Ready() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return len(s.nodes.prev) != 0
+	return len(s.nodes.prev) != 0 || len(s.pods.prev) != 0
 }
 
 func (s *storage) GetNodeMetrics(nodes ...string) ([]api.TimeInfo, []corev1.ResourceList, error) {

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -145,7 +145,7 @@ var _ = Describe("MetricsServer", func() {
 [+]poststarthook/generic-apiserver-start-informers ok
 [+]informer-sync ok
 [+]poststarthook/max-in-flight-filter ok
-[+]metric-collection-successful ok
+[+]metric-storage-ready ok
 [+]metadata-informer-sync ok
 [+]shutdown ok
 readyz check passed


### PR DESCRIPTION
* Add initial delay to readiness probe to give time for bootstrap and
two scrapes (first scrape is done as part of bootstrap)
* Add logging of server probes to make issues more visible to users
* Don't require scrape to return at least one node, just storage to be ready to serve
metrics.
* Storage ready also check pods to allow failed node metric storage
(improves stability for single node clusters)
* Require at least 2 stores of metrics to storage for it to be ready
(prepare for container start detection which can add to prev map in one
scrape)

/cc @dgrisonnet 