### PR TITLE
Cleanup logging of scrape errors

### DIFF
--- a/pkg/scraper/scraper.go
+++ b/pkg/scraper/scraper.go
@@ -16,7 +16,6 @@ package scraper
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"time"
 
@@ -169,7 +168,7 @@ func (c *scraper) collectNode(ctx context.Context, node *corev1.Node) (*storage.
 
 	if err != nil {
 		requestTotal.WithLabelValues("false").Inc()
-		return nil, fmt.Errorf("unable to fetch metrics from node %s: %v", node.Name, err)
+		return nil, err
 	}
 	requestTotal.WithLabelValues("true").Inc()
 	return ms, nil

--- a/pkg/utils/address_resolver.go
+++ b/pkg/utils/address_resolver.go
@@ -63,7 +63,7 @@ func (r *prioNodeAddrResolver) NodeAddress(node *corev1.Node) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("node %s had no addresses that matched types %v", node.Name, r.addrTypePriority)
+	return "", fmt.Errorf("no address matched types %v", r.addrTypePriority)
 }
 
 // NewPriorityNodeAddressResolver creates a new NodeAddressResolver that resolves


### PR DESCRIPTION
Noticed that logs have a lot of duplicated information stored in errors. This PR removes unnessesery error wrapping and removes adding node information to error.
/cc @dgrisonnet @yangjunmyfm192085 