### PR TITLE
manifests: Improve "autoscale" kustomization

### DIFF
--- a/manifests/autoscale/kustomization.yaml
+++ b/manifests/autoscale/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-  - ../base
 patchesStrategicMerge:
   - patch.yaml
 

--- a/manifests/autoscale/patch.yaml
+++ b/manifests/autoscale/patch.yaml
@@ -8,6 +8,10 @@ spec:
   template:
     spec:
       containers:
+        - name: metrics-server
+          # Resources are set by the nanny sidecar
+          resources:
+            $patch: delete
         - name: metrics-server-nanny
           image: k8s.gcr.io/addon-resizer:1.8.11
           resources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

* Remove "base" base: Allows user to use "autoscale" along "base",
  "release", or "test". Example:

  ```yaml
  apiVersion: kustomize.config.k8s.io/v1beta1
  kind: Kustomization
  resources:
  - github.com/kubernetes-sigs/metrics-server/manifests/release?ref=v0.5.0
  - github.com/kubernetes-sigs/metrics-server/manifests/autoscale?ref=v0.5.0
  ```

* Delete metrics-server container resources: Since they are managed by
  the nanny sidecar, re-applying the manifest could restart the deployment
  unnecessarily. This is especially obvious with a GitOps tool like Argo CD,
  which would show a diff between manifest and resources set by the addon-resizer

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

