### PR TITLE
manifests: Add RBAC for autoscale

### DIFF
--- a/manifests/autoscale/kustomization.yaml
+++ b/manifests/autoscale/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+resources:
+- rbac.yaml
 patchesStrategicMerge:
   - patch.yaml
 

--- a/manifests/autoscale/rbac.yaml
+++ b/manifests/autoscale/rbac.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:metrics-server-nanny
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:metrics-server-nanny
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server-nanny
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: metrics-server-nanny
+  namespace: kube-system
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  resourceNames:
+  - metrics-server
+  verbs:
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: metrics-server-nanny
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: metrics-server-nanny
+subjects:
+  - kind: ServiceAccount
+    name: metrics-server
+    namespace: kube-system


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

* The addon-resizer requires extra permissions to access the Kubernetes API
    * Get the `/metrics` endpoint: https://github.com/kubernetes/autoscaler/blob/addon-resizer-1.8.11/addon-resizer/nanny/kubernetes_client.go#L83-L89
    * Get and update the `metrics-server` deployment: https://github.com/kubernetes/autoscaler/blob/addon-resizer-1.8.11/addon-resizer/nanny/kubernetes_client.go#L144-L162

The `system:metrics-server` ClusterRole could be patch, but I decided to create separate RBAC resources for the nanny container.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

