### PR TITLE
Allow users to configure audit logs

### DIFF
--- a/cmd/metrics-server/app/options/options.go
+++ b/cmd/metrics-server/app/options/options.go
@@ -37,6 +37,7 @@ type Options struct {
 	SecureServing  *genericoptions.SecureServingOptionsWithLoopback
 	Authentication *genericoptions.DelegatingAuthenticationOptions
 	Authorization  *genericoptions.DelegatingAuthorizationOptions
+	Audit          *genericoptions.AuditOptions
 	Features       *genericoptions.FeatureOptions
 	KubeletClient  *KubeletClientOptions
 
@@ -66,6 +67,7 @@ func (o *Options) Flags() (fs flag.NamedFlagSets) {
 	o.SecureServing.AddFlags(fs.FlagSet("apiserver secure serving"))
 	o.Authentication.AddFlags(fs.FlagSet("apiserver authentication"))
 	o.Authorization.AddFlags(fs.FlagSet("apiserver authorization"))
+	o.Audit.AddFlags(fs.FlagSet("apiserver audit log"))
 	o.Features.AddFlags(fs.FlagSet("features"))
 
 	return fs
@@ -78,6 +80,7 @@ func NewOptions() *Options {
 		Authentication: genericoptions.NewDelegatingAuthenticationOptions(),
 		Authorization:  genericoptions.NewDelegatingAuthorizationOptions(),
 		Features:       genericoptions.NewFeatureOptions(),
+		Audit:          genericoptions.NewAuditOptions(),
 		KubeletClient:  NewKubeletClientOptions(),
 
 		MetricResolution: 60 * time.Second,
@@ -120,6 +123,11 @@ func (o Options) ApiserverConfig() (*genericapiserver.Config, error) {
 			return nil, err
 		}
 	}
+
+	if err := o.Audit.ApplyTo(serverConfig); err != nil {
+		return nil, err
+	}
+
 	versionGet := version.Get()
 	serverConfig.Version = &versionGet
 	// enable OpenAPI schemas


### PR DESCRIPTION
Audit logs can be very helpful when debugging requests coming to the
metrics server. They provide insights on the requested resources as well
are information on the user that sent the requests. This is helpful when
trying to narrow down applications spamming the server. Also, we can
configure the audit logs to provide even more information such as the
content of the response which is very helpful when trying to introspect
incorrect data.

/cc @serathius @yangjunmyfm192085 
