### PR TITLE
Add high availability configuration

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,3 +18,4 @@ jobs:
         with:
           files: |
             _output/components.yaml
+            _output/high-availability.yaml

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ release-tag:
 release-manifests:
 	mkdir -p _output
 	kubectl kustomize manifests/release > _output/components.yaml
+	kubectl kustomize manifests/high-availability > _output/high-availability.yaml
 
 # Unit tests
 # ----------

--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ Metrics Server | Metrics API group/version | Supported Kubernetes version
 
 [Metrics Server releases]: https://github.com/kubernetes-sigs/metrics-server/releases
 
+### High Availability
+
+Latest Metrics Server release can be installed in high availability mode by running:
+
+```shell
+kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/high-availability.yaml
+```
+
+Note that this configuration **requires** having a cluster with at least 2 nodes on which Metrics Server can be scheduled.
+
+Also, to maximize the efficiency of this highly available configuration, it is **recommended** to add the `--enable-aggregator-routing=true` CLI flag to the kube-apiserver so that requests sent to Metrics Server are load balanced between the 2 instances.
+
 ## Security context
 
 Metrics Server requires the `CAP_NET_BIND_SERVICE` capability in order to bind to a privileged ports as non-root.

--- a/manifests/high-availability/kustomization.yaml
+++ b/manifests/high-availability/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../release
+resources:
+- pdb.yaml
+patches:
+- path: patch.yaml
+  target:
+    kind: Deployment

--- a/manifests/high-availability/patch.yaml
+++ b/manifests/high-availability/patch.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-server
+spec:
+  replicas: 2
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                k8s-app: metrics-server
+            namespaces:
+            - kube-system
+            topologyKey: kubernetes.io/hostname

--- a/manifests/high-availability/pdb.yaml
+++ b/manifests/high-availability/pdb.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: metrics-server
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      k8s-app: metrics-server

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -15,4 +15,10 @@ build:
 deploy:
   kustomize:
     paths:
-    - manifests/test
+      - manifests/test
+profiles:
+  - name: high-availability
+    deploy:
+      kustomize:
+        paths:
+          - manifests/high-availability


### PR DESCRIPTION
**What this PR does / why we need it**:

Add highly available configuration to Metrics Server's manifests that
would allow to prevent disruption from impacting the kube-apiserver and
the autoscaling pipelines.

This new configuration is based on the release manifests and adds:
- 2 replicas of Metrics Server instead of 1
- PodDisruptionBudget with minAvailable: 1
- hard anti-affinity on hostname
- rolling update strategy with maxUnavailable: 1

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #552 #764

/cc @serathius @yangjunmyfm192085 
