### PR TITLE
Automate release manifests publication

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,20 @@
+name: Release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build manifests
+        run: make release-manifests
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            _output/components.yaml

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,6 @@ release-tag:
 release-manifests:
 	mkdir -p _output
 	kubectl kustomize manifests/release > _output/components.yaml
-	echo "Please upload file _output/components.yaml to GitHub release"
 
 # Unit tests
 # ----------

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,6 @@ The Metrics Server is released on an as-needed basis. The process is as follows:
 1. An OWNER creates a release tag using `GIT_TAG=$VERSION make release-tag` and waits for [prow.k8s.io](prow.k8s.io) to build and push new images to [gcr.io/k8s-staging-metrics-server](https://gcr.io/k8s-staging-metrics-server)
 1. An OWNER builds the release manifests using `make release-manifests` and uploads them to Github release
 1. A PR in [kubernetes/k8s.io](https://github.com/kubernetes/k8s.io/blob/main/k8s.gcr.io/images/k8s-staging-metrics-server/images.yaml) is created to release images to `k8s.gcr.io`
-1. An OWNER publishes the GitHub release
+1. An OWNER publishes the GitHub release. Once published, release manifests will be automatically added to the release by CI.
 1. An announcement email is sent to `kubernetes-sig-instrumentation@googlegroups.com` with the subject `[ANNOUNCE] metrics-server $VERSION is released`
 1. The release issue is closed


### PR DESCRIPTION
Automate release manifests publication by running a github action job that will generate and publish the manifests whenever a new github release is created.

I tested this job on my fork and the assets are published whenever a new github release is created.

/cc @serathius @yangjunmyfm192085 

