### PR TITLE
wait to be able to compute the resource usage of all the containers of a pod before exposing its PodMetrics.

### DIFF
--- a/pkg/storage/pod.go
+++ b/pkg/storage/pod.go
@@ -62,10 +62,12 @@ func (s *podStorage) GetMetrics(pods ...apitypes.NamespacedName) ([]api.TimeInfo
 			cms              = make([]metrics.ContainerMetrics, 0, len(lastPod.Containers))
 			earliestTimeInfo api.TimeInfo
 		)
+		allContainersPresent := true
 		for container, lastContainer := range lastPod.Containers {
 			prevContainer, found := prevPod.Containers[container]
 			if !found {
-				continue
+				allContainersPresent = false
+				break
 			}
 			usage, ti, err := resourceUsage(lastContainer, prevContainer)
 			if err != nil {
@@ -80,8 +82,10 @@ func (s *podStorage) GetMetrics(pods ...apitypes.NamespacedName) ([]api.TimeInfo
 				earliestTimeInfo = ti
 			}
 		}
-		ms[i] = cms
-		tis[i] = earliestTimeInfo
+		if allContainersPresent {
+			ms[i] = cms
+			tis[i] = earliestTimeInfo
+		}
 	}
 	return tis, ms, nil
 }


### PR DESCRIPTION
Signed-off-by: JunYang <yang.jun22@zte.com.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
There are many ci failuers recently
Based on previous research, Within two cycles of resource reporting, a container of the pod reported duplicate data, we skip the containers for which we can't compute the resource usage instead of skipping the whole PodMetrics.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

