### PR TITLE
Run e2e tests with high availability configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,6 @@ test-cli: container
 .PHONY: test-e2e
 test-e2e: test-e2e-1.21
 
-
 .PHONY: test-e2e-all
 test-e2e-all: test-e2e-1.21 test-e2e-1.20 test-e2e-1.19
 
@@ -153,6 +152,14 @@ test-e2e-1.20:
 .PHONY: test-e2e-1.19
 test-e2e-1.19:
 	NODE_IMAGE=kindest/node:v1.19.11@sha256:7664f21f9cb6ba2264437de0eb3fe99f201db7a3ac72329547ec4373ba5f5911 ./test/test-e2e.sh
+
+.PHONY: test-e2e-ha
+test-e2e-ha:
+	HIGH_AVAILABILITY=true $(MAKE) test-e2e
+
+.PHONY: test-e2e-ha-all
+test-e2e-ha-all:
+	HIGH_AVAILABILITY=true $(MAKE) test-e2e-all
 
 # Static analysis
 # ---------------

--- a/manifests/test-ha/kustomization.yaml
+++ b/manifests/test-ha/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../high-availability
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: metrics-server
+    namespace: kube-system
+  path: patch.yaml
+images:
+  - name: k8s.gcr.io/metrics-server/metrics-server
+    newName: gcr.io/k8s-staging-metrics-server/metrics-server
+    newTag: master

--- a/manifests/test-ha/patch.yaml
+++ b/manifests/test-ha/patch.yaml
@@ -1,0 +1,6 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --kubelet-insecure-tls
+- op: add
+  path: /spec/template/spec/containers/0/imagePullPolicy
+  value: Never

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -15,10 +15,10 @@ build:
 deploy:
   kustomize:
     paths:
-      - manifests/test
+    - manifests/test
 profiles:
-  - name: high-availability
+  - name: test-ha
     deploy:
       kustomize:
         paths:
-          - manifests/high-availability
+        - manifests/test-ha

--- a/test/kind-ha-config.yaml
+++ b/test/kind-ha-config.yaml
@@ -1,0 +1,6 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+- role: worker

--- a/test/kind-ha-config.yaml
+++ b/test/kind-ha-config.yaml
@@ -2,5 +2,11 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs:
+        "enable-aggregator-routing": "true"
 - role: worker
 - role: worker

--- a/test/test-e2e.sh
+++ b/test/test-e2e.sh
@@ -56,7 +56,7 @@ deploy_metrics_server(){
   if [ "${HIGH_AVAILABILITY}" = true ] ; then
     SKAFFOLD_PROFILE="test-ha"
   fi
-  PATH="$PWD/_output:${PATH}" ${SKAFFOLD} run -p ${SKAFFOLD_PROFILE}
+  PATH="$PWD/_output:${PATH}" ${SKAFFOLD} run -p "${SKAFFOLD_PROFILE}"
   sleep 5
 }
 

--- a/test/test-e2e.sh
+++ b/test/test-e2e.sh
@@ -3,6 +3,7 @@
 set -e
 
 : ${NODE_IMAGE:?Need to set NODE_IMAGE to test}
+: ${HIGH_AVAILABILITY:-false}
 
 KIND_VERSION=0.11.0
 SKAFFOLD_VERSION=1.24.1
@@ -40,14 +41,22 @@ setup_skaffold() {
 }
 
 create_cluster() {
-  if ! (${KIND} create cluster --name=e2e --image=${NODE_IMAGE}) ; then
+  KIND_CONFIG=""
+  if [ "${HIGH_AVAILABILITY}" = true ] ; then
+    KIND_CONFIG="$PWD/test/kind-ha-config.yaml"
+  fi
+  if ! (${KIND} create cluster --name=e2e --image=${NODE_IMAGE} --config=${KIND_CONFIG}) ; then
     echo "Could not create KinD cluster"
     exit 1
   fi
 }
 
 deploy_metrics_server(){
-  PATH="$PWD/_output:${PATH}" ${SKAFFOLD} run
+  SKAFFOLD_PROFILE=""
+  if [ "${HIGH_AVAILABILITY}" = true ] ; then
+    SKAFFOLD_PROFILE="test-ha"
+  fi
+  PATH="$PWD/_output:${PATH}" ${SKAFFOLD} run -p ${SKAFFOLD_PROFILE}
   sleep 5
 }
 


### PR DESCRIPTION
Add `test-e2e-ha` and `test-e2e-ha-all` Makefile rules to run the e2e
tests on the high availability configuration of metrics-server to
validate the manifests that are released.