### PR TITLE
api: Updates the resource names from (nodes, pods) to (nodemetrics, p…

### DIFF
--- a/pkg/api/install.go
+++ b/pkg/api/install.go
@@ -46,8 +46,8 @@ func Build(m MetricsGetter, podLister corev1.PodLister, nodeLister corev1.NodeLi
 	node := newNodeMetrics(metrics.Resource("nodemetrics"), m, nodeLister)
 	pod := newPodMetrics(metrics.Resource("podmetrics"), m, podLister)
 	metricsServerResources := map[string]rest.Storage{
-		"nodes": node,
-		"pods":  pod,
+		"nodemetrics": node,
+		"podmetrics":  pod,
 	}
 	apiGroupInfo.VersionedResourcesStorageMap[v1beta1.SchemeGroupVersion.Version] = metricsServerResources
 


### PR DESCRIPTION
…odmetrics)

In order for the 'kubectl explain' command to be conistent with other resources
this change alters the resource names to align with the CR Kind.

Fixes #813

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #813 

