### PR TITLE
Fix helm chart ci

### DIFF
--- a/.github/workflows/lint-test-chart.yaml
+++ b/.github/workflows/lint-test-chart.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.6.3
+          version: 3.*
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   release:
-    if: startsWith(github.ref, "refs/tags/v")
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,7 +24,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.6.3
+          version: 3.*
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.1

--- a/charts/metrics-server/README.md
+++ b/charts/metrics-server/README.md
@@ -2,6 +2,8 @@
 
 [Metrics Server](https://github.com/kubernetes-sigs/metrics-server/) is a scalable, efficient source of container resource metrics for Kubernetes built-in autoscaling pipelines.
 
+<!-- Trigger release -->
+
 ## Installing the Chart
 
 Before you can install the chart you will need to add the `metrics-server` repo to [Helm](https://helm.sh/).


### PR DESCRIPTION
This fixes the failing Release Chart  GH action, it's likely that the chart linting might fail with this but it shouldn't matter.