### PR TITLE
Fix test-e2e-ha CI job

### DIFF
--- a/manifests/high-availability/pdb.yaml
+++ b/manifests/high-availability/pdb.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: metrics-server


### PR DESCRIPTION
In the high availability manifests, we need to use the policy/v1beta1
API instead of policy/v1 to be compatible with all the supported
versions of Kubernetes since v1 was only released in 1.21.