### PR TITLE
Don‘t use Kubelet start time for metrics-server--master branch

### DIFF
--- a/pkg/storage/node.go
+++ b/pkg/storage/node.go
@@ -31,7 +31,7 @@ type nodeStorage struct {
 	// last stores node metric points from last scrape
 	last map[string]MetricsPoint
 	// prev stores node metric points from scrape preceding the last one.
-	// Points timestamp should proceed the corresponding points from last and have same start time (no restart between them).
+	// Points timestamp should proceed the corresponding points from last.
 	prev map[string]MetricsPoint
 }
 
@@ -69,8 +69,7 @@ func (s *nodeStorage) Store(batch *MetricsBatch) {
 		}
 		lastNodes[nodeName] = newPoint
 
-		// Keep previous metric point if newNode has not restarted (new metric start time < stored timestamp)
-		if lastNode, found := s.last[nodeName]; found && newPoint.StartTime.Before(lastNode.Timestamp) {
+		if lastNode, found := s.last[nodeName]; found {
 			// If new point is different then one already stored
 			if newPoint.Timestamp.After(lastNode.Timestamp) {
 				// Move stored point to previous


### PR DESCRIPTION
Signed-off-by: JunYang <yang.jun22@zte.com.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
we need delete Kubelet start time for metrics-server in master branch before merge #838
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

