### PR TITLE
manifests: Update addon-resizer to 1.8.14

### DIFF
--- a/manifests/autoscale/patch.yaml
+++ b/manifests/autoscale/patch.yaml
@@ -13,7 +13,7 @@ spec:
           resources:
             $patch: delete
         - name: metrics-server-nanny
-          image: k8s.gcr.io/addon-resizer:1.8.11
+          image: k8s.gcr.io/autoscaling/addon-resizer:1.8.14
           resources:
             limits:
               cpu: 40m

--- a/manifests/autoscale/rbac.yaml
+++ b/manifests/autoscale/rbac.yaml
@@ -29,6 +29,12 @@ metadata:
   namespace: kube-system
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
   - apps
   resources:
   - deployments
@@ -36,7 +42,7 @@ rules:
   - metrics-server
   verbs:
   - get
-  - update
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
**What this PR does / why we need it**:

* Support Kubernetes 1.22: dependencies updated in 1.8.14
* `patch` replaces `update` since 1.8.13
* Require pod permission explicitly. If something changes on the metrics-server side, it should not break its nanny

Relevant changelogs:
* https://github.com/kubernetes/autoscaler/releases/addon-resizer-1.8.14
* https://github.com/kubernetes/autoscaler/releases/addon-resizer-1.8.13
* https://github.com/kubernetes/autoscaler/releases/addon-resizer-1.8.12

**Which issue(s) this PR fixes**:

Related to https://github.com/kubernetes-sigs/metrics-server/issues/804#issuecomment-927137507

