### PR TITLE
Updates E2E test images registry

### DIFF
--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -485,7 +485,7 @@ func consumeCPU(client clientset.Interface, podName string) error {
 				Name:    podName,
 				Command: []string{"./consume-cpu/consume-cpu"},
 				Args:    []string{"--duration-sec=60", "--millicores=50"},
-				Image:   "gcr.io/kubernetes-e2e-test-images/resource-consumer:1.5",
+				Image:   "k8s.gcr.io/e2e-test-images/resource-consumer:1.9",
 				Resources: corev1.ResourceRequirements{
 					Requests: map[corev1.ResourceName]resource.Quantity{
 						corev1.ResourceCPU: mustQuantity("100m"),
@@ -510,7 +510,7 @@ func consumeMemory(client clientset.Interface, podName string) error {
 				Name:    podName,
 				Command: []string{"stress"},
 				Args:    []string{"-m", "1", "--vm-bytes", "50M", "--vm-hang", "0", "-t", "60"},
-				Image:   "gcr.io/kubernetes-e2e-test-images/resource-consumer:1.5",
+				Image:   "k8s.gcr.io/e2e-test-images/resource-consumer:1.9",
 				Resources: corev1.ResourceRequirements{
 					Requests: map[corev1.ResourceName]resource.Quantity{
 						corev1.ResourceMemory: mustQuantity("100Mi"),
@@ -534,7 +534,7 @@ func consumeWithInitContainer(client clientset.Interface, podName string) error 
 				Name:    podName,
 				Command: []string{"./consume-cpu/consume-cpu"},
 				Args:    []string{"--duration-sec=60", "--millicores=50"},
-				Image:   "gcr.io/kubernetes-e2e-test-images/resource-consumer:1.5",
+				Image:   "k8s.gcr.io/e2e-test-images/resource-consumer:1.9",
 				Resources: corev1.ResourceRequirements{
 					Requests: map[corev1.ResourceName]resource.Quantity{
 						corev1.ResourceCPU:    mustQuantity("100m"),
@@ -548,7 +548,7 @@ func consumeWithInitContainer(client clientset.Interface, podName string) error 
 					Name:    "init-container",
 					Command: []string{"./consume-cpu/consume-cpu"},
 					Args:    []string{"--duration-sec=10", "--millicores=50"},
-					Image:   "gcr.io/kubernetes-e2e-test-images/resource-consumer:1.5",
+					Image:   "k8s.gcr.io/e2e-test-images/resource-consumer:1.9",
 				},
 			}},
 	}
@@ -568,7 +568,7 @@ func consumeWithSideCarContainer(client clientset.Interface, podName string) err
 				Name:    podName,
 				Command: []string{"./consume-cpu/consume-cpu"},
 				Args:    []string{"--duration-sec=60", "--millicores=50"},
-				Image:   "gcr.io/kubernetes-e2e-test-images/resource-consumer:1.5",
+				Image:   "k8s.gcr.io/e2e-test-images/resource-consumer:1.9",
 				Resources: corev1.ResourceRequirements{
 					Requests: map[corev1.ResourceName]resource.Quantity{
 						corev1.ResourceCPU:    mustQuantity("100m"),
@@ -580,7 +580,7 @@ func consumeWithSideCarContainer(client clientset.Interface, podName string) err
 				Name:    "sidecar-container",
 				Command: []string{"./consume-cpu/consume-cpu"},
 				Args:    []string{"--duration-sec=60", "--millicores=50"},
-				Image:   "gcr.io/kubernetes-e2e-test-images/resource-consumer:1.5",
+				Image:   "k8s.gcr.io/e2e-test-images/resource-consumer:1.9",
 				Resources: corev1.ResourceRequirements{
 					Requests: map[corev1.ResourceName]resource.Quantity{
 						corev1.ResourceCPU:    mustQuantity("100m"),


### PR DESCRIPTION
We're moving away from google.com gcp projects. These images are now on community-owned infra.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

We're moving away from google.com gcp projects. These images are now on community-owned infra.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related: https://github.com/kubernetes/k8s.io/issues/1522

