### PR TITLE
Add Helm repo owners

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,2 +1,8 @@
 repositoryID: 10221ad5-0174-4a90-9bad-1c41b9904261
-owners: []
+owners:
+  - name: K8s Steering Committee 1
+    email: sc1@kubernetes.io
+  - name: K8s Steering Committee 2
+    email: sc2@kubernetes.io
+  - name: K8s Steering Committee 3
+    email: sc3@kubernetes.io


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR adds the correct owners to the [Artifact Hub repository](https://artifacthub.io/packages/search?repo=metrics-server&sort=relevance&page=1) so the repo can be claimed by the Kubernetes SIGs organisation.