### PR TITLE
Update index for chart v3.6.0

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -29,4 +29,35 @@ entries:
       urls:
       - https://github.com/kubernetes-sigs/metrics-server/releases/download/metrics-server-helm-chart-3.5.0/metrics-server-3.5.0.tgz
       version: 3.5.0
-generated: "2021-09-10T15:30:00.020215102Z"
+    - annotations:
+        artifacthub.io/changes: |
+          - kind: added
+            description: "New defaultArgs value to enable overriding the default arguments."
+          - kind: changed
+            description: "Update Metrics Server image to v0.5.1."
+      apiVersion: v2
+      appVersion: 0.5.1
+      description: Metrics Server is a scalable, efficient source of container resource
+        metrics for Kubernetes built-in autoscaling pipelines.
+      home: https://github.com/kubernetes-sigs/metrics-server
+      icon: https://avatars.githubusercontent.com/u/36015203?s=400&v=4
+      keywords:
+      - kubernetes
+      - metrics-server
+      - metrics
+      maintainers:
+      - name: stevehipwell
+        url: https://github.com/stevehipwell
+      - name: krmichel
+        url: https://github.com/krmichel
+      - name: endrec
+        url: https://github.com/endrec
+      name: metrics-server
+      sources:
+      - https://github.com/kubernetes-sigs/metrics-server
+      type: application
+      urls:
+      - https://github.com/kubernetes-sigs/metrics-server/releases/download/metrics-server-helm-chart-3.6.0/metrics-server-3.6.0.tgz
+      version: 3.6.0
+
+generated: "2021-10-18T16:00:00.020215102Z"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PRs manually adds the [broken](https://github.com/kubernetes-sigs/metrics-server/runs/3928148649?check_suite_focus=true) [v3.6.0](https://github.com/kubernetes-sigs/metrics-server/releases/tag/metrics-server-helm-chart-3.6.0) release from the repository.

