### PR TITLE
chore: specify output type for `docker buildx`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 # --------------------------
 REGISTRY?=gcr.io/k8s-staging-metrics-server
 ARCH?=amd64
+# The output type could either be docker (local), or registry.
+OUTPUT_TYPE ?= docker
 
 # Release variables
 # ------------------
@@ -45,7 +47,7 @@ container:
 	# Pull base image explicitly. Keep in sync with Dockerfile, otherwise
 	# GCB builds will start failing.
 	docker pull golang:1.17.1
-	docker build -t $(REGISTRY)/metrics-server-$(ARCH):$(CHECKSUM) --build-arg ARCH=$(ARCH) --build-arg GIT_TAG=$(GIT_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) .
+	docker buildx build --output=type=$(OUTPUT_TYPE) --platform linux/$(ARCH) -t $(REGISTRY)/metrics-server-$(ARCH):$(CHECKSUM) --build-arg ARCH=$(ARCH) --build-arg GIT_TAG=$(GIT_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) .
 
 .PHONY: container-all
 container-all: $(CONTAINER_ARCH_TARGETS);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Currently no output of `docker buildx` is used and the image will remain in the build cache. we want to make the output more configurable for different kinds of customer needs. The intentions of this PR are:
- specify --plaftform to build a multi-arch image
- expose OUTPUT_TYPE to allow the image built to be exposed to local docker or remote registry.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

