### PR TITLE
Specify the arch passed as build arg in the distroless image (#848)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Update the base image in Makefile when updating golang version. This has to
 # be pre-pulled in order to work on GCB.
+ARG ARCH
 FROM golang:1.17.1 as build
 
 RUN apt-get update && apt-get --no-install-recommends install -y libcap2-bin && apt-get clean && rm -rf /var/lib/apt/lists/* 
@@ -19,7 +20,7 @@ ARG GIT_TAG
 RUN make metrics-server
 RUN setcap cap_net_bind_service=+ep metrics-server
 
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static:latest-$ARCH
 COPY --from=build /go/src/sigs.k8s.io/metrics-server/metrics-server /
 USER 65534
 ENTRYPOINT ["/metrics-server"]

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -11,6 +11,7 @@ build:
     docker:
       dockerfile: Dockerfile
       buildArgs:
+        ARCH: "amd64"
         GIT_TAG: "devel"
 deploy:
   kustomize:


### PR DESCRIPTION
**What this PR does / why we need it**:
I moved `ARG ARCH` to the start so that it can be used in the last stage (`gcr.io/distroless/static:latest-$ARCH`). It is declared again below `FROM golang:1.17.1 as build` so that it is available when `make metrics-server` is run.

I tested with the architectures defined in the `Makefile`, each of which worked as expected.
https://github.com/kubernetes-sigs/metrics-server/blob/master/Makefile#L14
```
$ docker buildx build -t kubernetes-sigs/metrics-server:<arch> \
    --build-arg ARCH=<arch> \
    --build-arg GIT_COMMIT=foo \
    --build-arg GIT_TAG=bar .
```

"foo" and "bar" came back in the logs for `make metrics-server` as well, indicating that these are available as environment variables. I wanted to test this as well because I only noticed later that `ARCH` was not available anymore when I moved `ARG ARCH` to the start.

I don't know exactly where these images are built but it would be better to compare the architecture of the image that was built with the expected architecture, to prevent a regression in the future.

**Which issue(s) this PR fixes**:
Fixes #848

