### PR TITLE
Remove elevated permissions from metrics-server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@
 ARG ARCH
 FROM golang:1.17.1 as build
 
-RUN apt-get update && apt-get --no-install-recommends install -y libcap2-bin && apt-get clean && rm -rf /var/lib/apt/lists/* 
-
 WORKDIR /go/src/sigs.k8s.io/metrics-server
 COPY go.mod .
 COPY go.sum .
@@ -18,7 +16,6 @@ ARG ARCH
 ARG GIT_COMMIT
 ARG GIT_TAG
 RUN make metrics-server
-RUN setcap cap_net_bind_service=+ep metrics-server
 
 FROM gcr.io/distroless/static:latest-$ARCH
 COPY --from=build /go/src/sigs.k8s.io/metrics-server/metrics-server /

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ container:
 	# Pull base image explicitly. Keep in sync with Dockerfile, otherwise
 	# GCB builds will start failing.
 	docker pull golang:1.17.1
-	docker buildx build -t $(REGISTRY)/metrics-server-$(ARCH):$(CHECKSUM) --build-arg ARCH=$(ARCH) --build-arg GIT_TAG=$(GIT_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) .
+	docker build -t $(REGISTRY)/metrics-server-$(ARCH):$(CHECKSUM) --build-arg ARCH=$(ARCH) --build-arg GIT_TAG=$(GIT_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) .
 
 .PHONY: container-all
 container-all: $(CONTAINER_ARCH_TARGETS);

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
           - --cert-dir=/tmp
-          - --secure-port=443
+          - --secure-port=4443
           - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
           - --kubelet-use-node-status-port
           - --metric-resolution=15s
@@ -32,7 +32,7 @@ spec:
             memory: 200Mi
         ports:
         - name: https
-          containerPort: 443
+          containerPort: 4443
           protocol: TCP
         readinessProbe:
           httpGet:

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -225,7 +225,7 @@ livez check passed
 	It("exposes prometheus metrics", func() {
 		msPods := mustGetMetricsServerPods(client)
 		for _, pod := range msPods {
-			resp, err := proxyRequestToPod(restConfig, pod.Namespace, pod.Name, "https", 443, "/metrics")
+			resp, err := proxyRequestToPod(restConfig, pod.Namespace, pod.Name, "https", 4443, "/metrics")
 			Expect(err).NotTo(HaveOccurred(), "Failed to get Metrics Server /metrics endpoint")
 			metrics, err := parseMetricNames(resp)
 			Expect(err).NotTo(HaveOccurred(), "Failed to parse Metrics Server metrics")


### PR DESCRIPTION
#### Description
A non-privileged port 10250 is used as targetPort, which enables the
removal of capability cap_net_bind_service, please refer to
https://github.com/kubernetes/kubernetes/pull/105957

#### Testing
* Manual Testing
Create a k8s cluster using kubetest2 with gce as provider and deploy metrics-server with the update image. Manually query metrics.k8s.io API.

```
kubectl get --raw /apis/metrics.k8s.io/v1beta1/nodes
kubectl get --raw /apis/metrics.k8s.io/v1beta1/nodes/${worker_node}
kubectl get --raw /apis/metrics.k8s.io/v1beta1/pods
kubectl get --raw /apis/metrics.k8s.io/v1beta1/namespaces/kube-system/pods/${system_pod}
kubectl get --raw /apis/metrics.k8s.io/v1beta1/namespaces/default/pods/${user_pod}
```

* Unit Testing & e2e Testing
```
make test-unit
make test-version
make test-e2e
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR rolls back capability cap_net_bind_service.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
No

