### PR TITLE
Add "allowPrivilegeEscalation" to the Kustomize template (#881)

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -53,6 +53,7 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1000
+          allowPrivilegeEscalation: false
         volumeMounts:
         - name: tmp-dir
           mountPath: /tmp


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `allowPrivilegeEscalation: false` to the Kustomize template such that it matches the Helm chart.

**Which issue(s) this PR fixes**:
Fixes #881

