### PR TITLE
Cherrypick pull request #884 from shuaich/remove_elevated_permission to release-0.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@
 # be pre-pulled in order to work on GCB.
 FROM golang:1.16.8 as build
 
-RUN apt-get update && apt-get --no-install-recommends install -y libcap2-bin && apt-get clean && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /go/src/sigs.k8s.io/metrics-server
 COPY go.mod .
 COPY go.sum .
@@ -17,7 +15,6 @@ ARG ARCH
 ARG GIT_COMMIT
 ARG GIT_TAG
 RUN make metrics-server
-RUN setcap cap_net_bind_service=+ep metrics-server
 
 FROM gcr.io/distroless/static:latest
 COPY --from=build /go/src/sigs.k8s.io/metrics-server/metrics-server /

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ container:
 	# Pull base image explicitly. Keep in sync with Dockerfile, otherwise
 	# GCB builds will start failing.
 	docker pull golang:1.16.8
-	docker buildx build -t $(REGISTRY)/metrics-server-$(ARCH):$(CHECKSUM) --build-arg ARCH=$(ARCH) --build-arg GIT_TAG=$(GIT_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) .
+	docker build -t $(REGISTRY)/metrics-server-$(ARCH):$(CHECKSUM) --build-arg ARCH=$(ARCH) --build-arg GIT_TAG=$(GIT_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) .
 
 .PHONY: container-all
 container-all: $(CONTAINER_ARCH_TARGETS);

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
           - --cert-dir=/tmp
-          - --secure-port=443
+          - --secure-port=4443
           - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
           - --kubelet-use-node-status-port
           - --metric-resolution=15s
@@ -32,7 +32,7 @@ spec:
             memory: 200Mi
         ports:
         - name: https
-          containerPort: 443
+          containerPort: 4443
           protocol: TCP
         readinessProbe:
           httpGet:

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -168,7 +168,7 @@ livez check passed
 	})
 	It("exposes prometheus metrics", func() {
 		msPod := mustGetMetricsServerPod(client)
-		resp, err := proxyRequestToPod(restConfig, msPod.Namespace, msPod.Name, "https", 443, "/metrics")
+		resp, err := proxyRequestToPod(restConfig, msPod.Namespace, msPod.Name, "https", 4443, "/metrics")
 		Expect(err).NotTo(HaveOccurred(), "Failed to get Metrics Server /metrics endpoint")
 		metrics, err := parseMetricNames(resp)
 		Expect(err).NotTo(HaveOccurred(), "Failed to parse Metrics Server metrics")


### PR DESCRIPTION
#### Description
Remove elevated permissions from metrics-server

#### Testing
```
make test-unit
make test-version
make test-e23
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR cherry picks https://github.com/kubernetes-sigs/metrics-server/pull/884 from master branch.
With this PR, we are able to remove elevated permissions from metrics-server.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

