### PR TITLE
[release-0.5] Specify the arch passed as build arg in the distroless image (#848)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Update the base image in Makefile when updating golang version. This has to
 # be pre-pulled in order to work on GCB.
+ARG ARCH
 FROM golang:1.16.8 as build
 
 WORKDIR /go/src/sigs.k8s.io/metrics-server
@@ -16,7 +17,7 @@ ARG GIT_COMMIT
 ARG GIT_TAG
 RUN make metrics-server
 
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static:latest-$ARCH
 COPY --from=build /go/src/sigs.k8s.io/metrics-server/metrics-server /
 USER 65534
 ENTRYPOINT ["/metrics-server"]

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -11,6 +11,7 @@ build:
     docker:
       dockerfile: Dockerfile
       buildArgs:
+        ARCH: "amd64"
         GIT_TAG: "devel"
 deploy:
   kustomize:


### PR DESCRIPTION
Backport https://github.com/kubernetes-sigs/metrics-server/pull/882 to release-0.5 branch