### PR TITLE
[release-0.4] Specify the arch passed as build arg in the distroless image (#848)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Update the base image in Makefile when updating golang version. This has to
 # be pre-pulled in order to work on GCB.
+ARG ARCH
 FROM golang:1.14.2 as build
 
 WORKDIR /go/src/sigs.k8s.io/metrics-server
@@ -17,7 +18,7 @@ ARG GIT_TAG
 ARG BUILD_DATE
 RUN make metrics-server
 
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static:latest-$ARCH
 COPY --from=build /go/src/sigs.k8s.io/metrics-server/metrics-server /
 USER 65534
 ENTRYPOINT ["/metrics-server"]


### PR DESCRIPTION
Backport of https://github.com/kubernetes-sigs/metrics-server/pull/882 to release-0.4 branch

/assign @dgrisonnet 

