### PR TITLE
chore(chart): fix manifest upload in chart release ci

### DIFF
--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -45,9 +45,16 @@ jobs:
           tag: "v${{ steps.chart_app_version.outputs.result }}"
           fileName: "components.yaml"
 
+      - name: Get chart version
+        id: chart_version
+        uses: mikefarah/yq@v4.12.2
+        with:
+          cmd: yq eval '.version' './charts/metrics-server/Chart.yaml'
+
       - name: Update release
         uses: ncipollo/release-action@v1
         with:
+          tag: "metrics-server-helm-chart-${{ steps.chart_version.outputs.result }}"
           allowUpdates: true
           artifacts: "components.yaml"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR fixes the manifest upload step run at the end of a chart release.

