### PR TITLE
Add chart CI for v0.6.0

### DIFF
--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -3,7 +3,7 @@ name: Release Chart
 on:
   push:
     branches:
-      - master
+      - release-*
     paths:
       - "charts/metrics-server/Chart.yaml"
 

--- a/charts/metrics-server/Chart.yaml
+++ b/charts/metrics-server/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "Add support for unauthenticated access to /metrics."
+      description: "Add support for unauthenticated access to /metrics endpoint."
     - kind: added
       description: "Add PrometheusOperator ServiceMonitor."
     - kind: changed


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR cherry-picks the chart CI from `master` that's required to publish the chart form the release branch. There is also an additional commit to the chart to trigger a release for v0.6.0.

**Which issue(s) this PR fixes**:
n/a

