### PR TITLE
Set Helm chart resource namespaces explicitly

### DIFF
--- a/charts/metrics-server/templates/deployment.yaml
+++ b/charts/metrics-server/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "metrics-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "metrics-server.labels" . | nindent 4 }}
 spec:

--- a/charts/metrics-server/templates/pdb.yaml
+++ b/charts/metrics-server/templates/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "metrics-server.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "metrics-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "metrics-server.labels" . | nindent 4 }}
 spec:

--- a/charts/metrics-server/templates/rolebinding.yaml
+++ b/charts/metrics-server/templates/rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ printf "%s-auth-reader" (include "metrics-server.fullname" .)  }}
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "metrics-server.labels" . | nindent 4 }}
 roleRef:

--- a/charts/metrics-server/templates/service.yaml
+++ b/charts/metrics-server/templates/service.yaml
@@ -2,12 +2,13 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "metrics-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "metrics-server.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  labels:
-    {{- include "metrics-server.labels" . | nindent 4 }}
   {{- with .Values.service.labels -}}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/metrics-server/templates/serviceaccount.yaml
+++ b/charts/metrics-server/templates/serviceaccount.yaml
@@ -3,10 +3,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "metrics-server.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "metrics-server.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  labels:
-    {{- include "metrics-server.labels" . | nindent 4 }}
 {{- end -}}

--- a/charts/metrics-server/templates/servicemonitor.yaml
+++ b/charts/metrics-server/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "metrics-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "metrics-server.labels" . | nindent 4 }}
     {{- with .Values.serviceMonitor.additionalLabels }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR explicitly sets the metadata namespace of all resources, which makes this consistent as RBAC resources need the release namespace templating into their spec anyway. This also makes it easier to read and understand the manifests generated by `helm template` as there is no information missing until apply.

**IMPORTANT** - This shouldn't be merged until either the release of the chart for `v0.7.0` or we're making other minor level chart changes as it shouldn't go out as a patch.

**Which issue(s) this PR fixes**:
Fixes #964.

