### PR TITLE
try to fix the e2e failure

### DIFF
--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -223,8 +223,11 @@ livez check passed
 		}
 	})
 	It("exposes prometheus metrics", func() {
+
 		msPods := mustGetMetricsServerPods(client)
 		for _, pod := range msPods {
+			_, err := proxyRequestToPod(restConfig, pod.Namespace, pod.Name, "https", 4443, "/apis/metrics.k8s.io/v1beta1/")
+			Expect(err).NotTo(HaveOccurred(), "Failed to get Metrics Server /apis/metrics.k8s.io/v1beta1/ endpoint")
 			resp, err := proxyRequestToPod(restConfig, pod.Namespace, pod.Name, "https", 4443, "/metrics")
 			Expect(err).NotTo(HaveOccurred(), "Failed to get Metrics Server /metrics endpoint")
 			metrics, err := parseMetricNames(resp)

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -223,9 +223,9 @@ livez check passed
 		}
 	})
 	It("exposes prometheus metrics", func() {
-
 		msPods := mustGetMetricsServerPods(client)
 		for _, pod := range msPods {
+			// access /apis/metrics.k8s.io/v1beta1/ for each pod to ensures that every MS instance get an requests so they expose all apiserver metrics.
 			_, err := proxyRequestToPod(restConfig, pod.Namespace, pod.Name, "https", 4443, "/apis/metrics.k8s.io/v1beta1/")
 			Expect(err).NotTo(HaveOccurred(), "Failed to get Metrics Server /apis/metrics.k8s.io/v1beta1/ endpoint")
 			resp, err := proxyRequestToPod(restConfig, pod.Namespace, pod.Name, "https", 4443, "/metrics")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

try to analyse the failure reason of pull-metrics-server-test-e2e-ha test. After modification, verify whether it can be successful

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #973

