### PR TITLE
add kubectl proxy description

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -34,12 +34,14 @@ You can do that by checking Summary API on nodes that are missing metrics.
 
 You can read JSON response returned by command below and check `.node.cpu` and `.node.memory` fields. 
 ```console
+kubectl proxy &
 NODE_NAME=<Name of node in your cluster>
 kubectl get --raw /api/v1/nodes/$NODE_NAME/proxy/stats/summary
 ```
 
 Alternativly you can run one liner using (requires [jq](https://stedolan.github.io/jq/)):
 ```
+kubectl proxy &
 NODE_NAME=<Name of node in your cluster>
 kubectl get --raw /api/v1/nodes/$NODE_NAME/proxy/stats/summary | jq '{cpu: .node.cpu, memory: .node.memory}'
 ```
@@ -69,6 +71,7 @@ If usage values are equal zero, means that there is problem is related to Kubele
 You can do that by checking resource metrics on nodes that are missing metrics.
 
 ```console
+kubectl proxy &
 NODE_NAME=<Name of node in your cluster>
 kubectl get --raw /api/v1/nodes/$NODE_NAME/proxy/metrics/resource
 ```
@@ -101,6 +104,7 @@ Please check if your Kubelet is correctly returning pod metrics.
 
 You can do that by checking Summary API on node where pod with missing metrics is running (can be checked by running `kubectl -n <pod_namespace> describe pod <pod_name>`:
 ```console
+kubectl proxy &
 NODE_NAME=<Name of node where pod runs>
 kubectl get --raw /api/v1/nodes/$NODE_NAME/proxy/stats/summary
 ```
@@ -110,6 +114,7 @@ Empty list of pods means that problem is related to Kubelet and not to Metrics S
 
 One liner for number of pod metrics reported by first node in cluster (requires [jq](https://stedolan.github.io/jq/)):
 ```console
+kubectl proxy &
 kubectl get --raw /api/v1/nodes/$(kubectl get nodes -o json  | jq -r '.items[0].metadata.name')/proxy/stats/summary | jq '.pods | length'
 ```
 
@@ -117,6 +122,7 @@ kubectl get --raw /api/v1/nodes/$(kubectl get nodes -o json  | jq -r '.items[0].
 
 You can do that by checking resource metrics on node where pod with missing metrics is running (can be checked by running `kubectl -n <pod_namespace> describe pod <pod_name>`:
 ```console
+kubectl proxy &
 NODE_NAME=<Name of node in your cluster>
 kubectl get --raw /api/v1/nodes/$NODE_NAME/proxy/metrics/resource
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Recently, when multiple users execute commands to obtain `stats/summary`/ `metrics/resource` according to known issues, they cannot operate correctly. such as [#990](https://github.com/kubernetes-sigs/metrics-server/issues/990)
I think we need to add the command
```
kubectl proxy 
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

