### PR TITLE
Remove redundant informer startup

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -66,7 +66,7 @@ func (c Config) Complete() (*server, error) {
 	if err != nil {
 		return nil, err
 	}
-	genericServer, err := c.Apiserver.Complete(informer).New("metrics-server", genericapiserver.NewEmptyDelegate())
+	genericServer, err := c.Apiserver.Complete(nil).New("metrics-server", genericapiserver.NewEmptyDelegate())
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -195,10 +195,9 @@ var _ = Describe("MetricsServer", func() {
 			resp := mustProxyContainerProbe(restConfig, pod.Namespace, pod.Name, pod.Spec.Containers[0], pod.Spec.Containers[0].ReadinessProbe)
 			diff := cmp.Diff(string(resp), `[+]ping ok
 [+]log ok
-[+]poststarthook/generic-apiserver-start-informers ok
-[+]informer-sync ok
 [+]poststarthook/max-in-flight-filter ok
 [+]metric-storage-ready ok
+[+]metric-informer-sync ok
 [+]metadata-informer-sync ok
 [+]shutdown ok
 readyz check passed
@@ -213,7 +212,6 @@ readyz check passed
 			resp := mustProxyContainerProbe(restConfig, pod.Namespace, pod.Name, pod.Spec.Containers[0], pod.Spec.Containers[0].LivenessProbe)
 			diff := cmp.Diff(string(resp), `[+]ping ok
 [+]log ok
-[+]poststarthook/generic-apiserver-start-informers ok
 [+]poststarthook/max-in-flight-filter ok
 [+]metric-collection-timely ok
 [+]metadata-informer-sync ok


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Analyzed according to issue https://github.com/kubernetes-sigs/metrics-server/issues/1002 We need to remove the redundant informer startup
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1002

