### PR TITLE
Optimize the timeout setting and timeout logging of metrics-server accessing the /metrics/resource endpoint

### DIFF
--- a/cmd/metrics-server/app/options/kubelet_client.go
+++ b/cmd/metrics-server/app/options/kubelet_client.go
@@ -64,7 +64,7 @@ func (o *KubeletClientOptions) Validate() []error {
 		errors = append(errors, fmt.Errorf("cannot use both --kubelet-certificate-authority and --deprecated-kubelet-completely-insecure"))
 	}
 	if o.KubeletRequestTimeout <= 0 {
-		errors = append(errors, fmt.Errorf("kubelet-request-timeout should be a positive number as time, but value %v provided", o.KubeletRequestTimeout))
+		errors = append(errors, fmt.Errorf("kubelet-request-timeout should be positive"))
 	}
 	return errors
 }

--- a/cmd/metrics-server/app/options/kubelet_client.go
+++ b/cmd/metrics-server/app/options/kubelet_client.go
@@ -63,6 +63,9 @@ func (o *KubeletClientOptions) Validate() []error {
 	if (o.KubeletCAFile != "") && o.DeprecatedCompletelyInsecureKubelet {
 		errors = append(errors, fmt.Errorf("cannot use both --kubelet-certificate-authority and --deprecated-kubelet-completely-insecure"))
 	}
+	if o.KubeletRequestTimeout <= 0 {
+		errors = append(errors, fmt.Errorf("kubelet-request-timeout should be a positive number as time, but value %v provided", o.KubeletRequestTimeout))
+	}
 	return errors
 }
 
@@ -74,7 +77,7 @@ func (o *KubeletClientOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.KubeletCAFile, "kubelet-certificate-authority", "", "Path to the CA to use to validate the Kubelet's serving certificates.")
 	fs.StringVar(&o.KubeletClientKeyFile, "kubelet-client-key", "", "Path to a client key file for TLS.")
 	fs.StringVar(&o.KubeletClientCertFile, "kubelet-client-certificate", "", "Path to a client cert file for TLS.")
-	fs.DurationVar(&o.KubeletRequestTimeout, "kubelet-request-timeout", o.KubeletRequestTimeout, "The timeout at request /metrics/resource endpoint of kubelet, must set value less than metric-resolution.")
+	fs.DurationVar(&o.KubeletRequestTimeout, "kubelet-request-timeout", o.KubeletRequestTimeout, "The timeout at request kubelet, must set value less than metric-resolution.")
 	// MarkDeprecated hides the flag from the help. We don't want that.
 	fs.BoolVar(&o.DeprecatedCompletelyInsecureKubelet, "deprecated-kubelet-completely-insecure", o.DeprecatedCompletelyInsecureKubelet, "DEPRECATED: Do not use any encryption, authorization, or authentication when communicating with the Kubelet. This is rarely the right option, since it leaves kubelet communication completely insecure.  If you encounter auth errors, make sure you've enabled token webhook auth on the Kubelet, and if you're in a test cluster with self-signed Kubelet certificates, consider using kubelet-insecure-tls instead.")
 }

--- a/cmd/metrics-server/app/options/kubelet_client.go
+++ b/cmd/metrics-server/app/options/kubelet_client.go
@@ -15,6 +15,7 @@ package options
 
 import (
 	"fmt"
+	"time"
 
 	"sigs.k8s.io/metrics-server/pkg/scraper/client"
 
@@ -35,6 +36,7 @@ type KubeletClientOptions struct {
 	KubeletClientKeyFile                string
 	KubeletClientCertFile               string
 	DeprecatedCompletelyInsecureKubelet bool
+	KubeletRequestTimeout               time.Duration
 }
 
 func (o *KubeletClientOptions) Validate() []error {
@@ -72,6 +74,7 @@ func (o *KubeletClientOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.KubeletCAFile, "kubelet-certificate-authority", "", "Path to the CA to use to validate the Kubelet's serving certificates.")
 	fs.StringVar(&o.KubeletClientKeyFile, "kubelet-client-key", "", "Path to a client key file for TLS.")
 	fs.StringVar(&o.KubeletClientCertFile, "kubelet-client-certificate", "", "Path to a client cert file for TLS.")
+	fs.DurationVar(&o.KubeletRequestTimeout, "kubelet-request-timeout", o.KubeletRequestTimeout, "The timeout at request /metrics/resource endpoint of kubelet, must set value less than metric-resolution.")
 	// MarkDeprecated hides the flag from the help. We don't want that.
 	fs.BoolVar(&o.DeprecatedCompletelyInsecureKubelet, "deprecated-kubelet-completely-insecure", o.DeprecatedCompletelyInsecureKubelet, "DEPRECATED: Do not use any encryption, authorization, or authentication when communicating with the Kubelet. This is rarely the right option, since it leaves kubelet communication completely insecure.  If you encounter auth errors, make sure you've enabled token webhook auth on the Kubelet, and if you're in a test cluster with self-signed Kubelet certificates, consider using kubelet-insecure-tls instead.")
 }
@@ -81,6 +84,7 @@ func NewKubeletClientOptions() *KubeletClientOptions {
 	o := &KubeletClientOptions{
 		KubeletPort:                  10250,
 		KubeletPreferredAddressTypes: make([]string, len(utils.DefaultAddressTypePriority)),
+		KubeletRequestTimeout:        10 * time.Second,
 	}
 
 	for i, addrType := range utils.DefaultAddressTypePriority {

--- a/cmd/metrics-server/app/options/kubelet_client.go
+++ b/cmd/metrics-server/app/options/kubelet_client.go
@@ -77,7 +77,7 @@ func (o *KubeletClientOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.KubeletCAFile, "kubelet-certificate-authority", "", "Path to the CA to use to validate the Kubelet's serving certificates.")
 	fs.StringVar(&o.KubeletClientKeyFile, "kubelet-client-key", "", "Path to a client key file for TLS.")
 	fs.StringVar(&o.KubeletClientCertFile, "kubelet-client-certificate", "", "Path to a client cert file for TLS.")
-	fs.DurationVar(&o.KubeletRequestTimeout, "kubelet-request-timeout", o.KubeletRequestTimeout, "The timeout at request kubelet, must set value less than metric-resolution.")
+	fs.DurationVar(&o.KubeletRequestTimeout, "kubelet-request-timeout", o.KubeletRequestTimeout, "The length of time to wait before giving up on a single request to Kubelet. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h).")
 	// MarkDeprecated hides the flag from the help. We don't want that.
 	fs.BoolVar(&o.DeprecatedCompletelyInsecureKubelet, "deprecated-kubelet-completely-insecure", o.DeprecatedCompletelyInsecureKubelet, "DEPRECATED: Do not use any encryption, authorization, or authentication when communicating with the Kubelet. This is rarely the right option, since it leaves kubelet communication completely insecure.  If you encounter auth errors, make sure you've enabled token webhook auth on the Kubelet, and if you're in a test cluster with self-signed Kubelet certificates, consider using kubelet-insecure-tls instead.")
 }

--- a/cmd/metrics-server/app/options/kubelet_client_test.go
+++ b/cmd/metrics-server/app/options/kubelet_client_test.go
@@ -15,6 +15,7 @@ package options
 
 import (
 	"testing"
+	"time"
 
 	"sigs.k8s.io/metrics-server/pkg/scraper/client"
 
@@ -164,14 +165,16 @@ func TestValidate(t *testing.T) {
 			options: &KubeletClientOptions{
 				DeprecatedCompletelyInsecureKubelet: true,
 				KubeletCAFile:                       "a",
+				KubeletRequestTimeout:               1 * time.Second,
 			},
 			expectedErrorCount: 1,
 		},
 		{
 			name: "Cannot use both --kubelet-certificate-authority and --kubelet-insecure-tls",
 			options: &KubeletClientOptions{
-				InsecureKubeletTLS: true,
-				KubeletCAFile:      "a",
+				InsecureKubeletTLS:    true,
+				KubeletCAFile:         "a",
+				KubeletRequestTimeout: 1 * time.Second,
 			},
 			expectedErrorCount: 1,
 		},
@@ -180,6 +183,7 @@ func TestValidate(t *testing.T) {
 			options: &KubeletClientOptions{
 				KubeletClientKeyFile:  "a",
 				KubeletClientCertFile: "b",
+				KubeletRequestTimeout: 1 * time.Second,
 			},
 			expectedErrorCount: 0,
 		},
@@ -188,6 +192,7 @@ func TestValidate(t *testing.T) {
 			options: &KubeletClientOptions{
 				KubeletClientCertFile:               "a",
 				DeprecatedCompletelyInsecureKubelet: true,
+				KubeletRequestTimeout:               1 * time.Second,
 			},
 			expectedErrorCount: 2,
 		},
@@ -196,6 +201,7 @@ func TestValidate(t *testing.T) {
 			options: &KubeletClientOptions{
 				KubeletClientKeyFile:                "a",
 				DeprecatedCompletelyInsecureKubelet: true,
+				KubeletRequestTimeout:               1 * time.Second,
 			},
 			expectedErrorCount: 2,
 		},
@@ -204,6 +210,7 @@ func TestValidate(t *testing.T) {
 			options: &KubeletClientOptions{
 				InsecureKubeletTLS:                  true,
 				DeprecatedCompletelyInsecureKubelet: true,
+				KubeletRequestTimeout:               1 * time.Second,
 			},
 			expectedErrorCount: 1,
 		},
@@ -211,13 +218,36 @@ func TestValidate(t *testing.T) {
 			name: "cannot give only --kubelet-client-key, give --kubelet-key-file as well",
 			options: &KubeletClientOptions{
 				KubeletClientCertFile: "a",
+				KubeletRequestTimeout: 1 * time.Second,
 			},
 			expectedErrorCount: 1,
 		},
 		{
 			name: "cannot give only --kubelet-client-key, give --kubelet-certificate-authority as well",
 			options: &KubeletClientOptions{
-				KubeletClientKeyFile: "a",
+				KubeletClientKeyFile:  "a",
+				KubeletRequestTimeout: 1 * time.Second,
+			},
+			expectedErrorCount: 1,
+		},
+		{
+			name: "can give --kubelet-request-timeout value larger than 0",
+			options: &KubeletClientOptions{
+				KubeletRequestTimeout: 1 * time.Second,
+			},
+			expectedErrorCount: 0,
+		},
+		{
+			name: "cannot give --kubelet-request-timeout value equal 0",
+			options: &KubeletClientOptions{
+				KubeletRequestTimeout: 0 * time.Second,
+			},
+			expectedErrorCount: 1,
+		},
+		{
+			name: "cannot give --kubelet-request-timeout value less than 0",
+			options: &KubeletClientOptions{
+				KubeletRequestTimeout: -10 * time.Second,
 			},
 			expectedErrorCount: 1,
 		},

--- a/cmd/metrics-server/app/options/options.go
+++ b/cmd/metrics-server/app/options/options.go
@@ -54,15 +54,21 @@ type Options struct {
 
 func (o *Options) Validate() []error {
 	errors := o.KubeletClient.Validate()
-	if o.MetricResolution < 10*time.Second {
-		errors = append(errors, fmt.Errorf("metric-resolution should be a time duration at least 10s, but value %v provided", o.MetricResolution))
-	}
-	if o.MetricResolution < o.KubeletClient.KubeletRequestTimeout {
-		errors = append(errors, fmt.Errorf("metric-resolution should be larger than kubelet-request-timeout, but metric-resolution value %v kubelet-request-timeout value %v provided", o.MetricResolution, o.KubeletClient.KubeletRequestTimeout))
-	}
+	errors = append(errors, o.validate()...)
 	err := o.Logging.ValidateAndApply()
 	if err != nil {
 		errors = append(errors, err)
+	}
+	return errors
+}
+
+func (o *Options) validate() []error {
+	errors := []error{}
+	if o.MetricResolution < 10*time.Second {
+		errors = append(errors, fmt.Errorf("metric-resolution should be a time duration at least 10s, but value %v provided", o.MetricResolution))
+	}
+	if o.MetricResolution*9/10 < o.KubeletClient.KubeletRequestTimeout {
+		errors = append(errors, fmt.Errorf("metric-resolution should be larger than kubelet-request-timeout, but metric-resolution value %v kubelet-request-timeout value %v provided", o.MetricResolution, o.KubeletClient.KubeletRequestTimeout))
 	}
 	return errors
 }

--- a/cmd/metrics-server/app/options/options.go
+++ b/cmd/metrics-server/app/options/options.go
@@ -44,9 +44,9 @@ type Options struct {
 	KubeletClient  *KubeletClientOptions
 	Logging        *logs.Options
 
-	MetricResolution      time.Duration
-	ShowVersion           bool
-	Kubeconfig            string
+	MetricResolution time.Duration
+	ShowVersion      bool
+	Kubeconfig       string
 
 	// Only to be used to for testing
 	DisableAuthForTesting bool
@@ -95,7 +95,7 @@ func NewOptions() *Options {
 		KubeletClient:  NewKubeletClientOptions(),
 		Logging:        logs.NewOptions(),
 
-		MetricResolution:      60 * time.Second,
+		MetricResolution: 60 * time.Second,
 	}
 }
 

--- a/cmd/metrics-server/app/options/options_test.go
+++ b/cmd/metrics-server/app/options/options_test.go
@@ -1,0 +1,55 @@
+// Copyright 2022 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package options
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/component-base/logs"
+)
+
+func TestOptions_validate(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		options            *Options
+		expectedErrorCount int
+	}{
+		{
+			name: "can give --metric-resolution larger than --kubelet-request-timeout",
+			options: &Options{
+				MetricResolution: 10 * time.Second,
+				KubeletClient:    &KubeletClientOptions{KubeletRequestTimeout: 9 * time.Second},
+				Logging:          logs.NewOptions(),
+			},
+			expectedErrorCount: 0,
+		},
+		{
+			name: "can not give --metric-resolution * 9/10 less than --kubelet-request-timeout",
+			options: &Options{
+				MetricResolution: 10 * time.Second,
+				KubeletClient:    &KubeletClientOptions{KubeletRequestTimeout: 10 * time.Second},
+				Logging:          logs.NewOptions(),
+			},
+			expectedErrorCount: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			errors := tc.options.validate()
+			if len(errors) != tc.expectedErrorCount {
+				t.Errorf("options.Validate() = %q, expected length %d", errors, tc.expectedErrorCount)
+			}
+		})
+	}
+}

--- a/docs/command-line-flags.txt
+++ b/docs/command-line-flags.txt
@@ -9,7 +9,6 @@ Metrics server flags:
       --metric-resolution duration   The resolution at which metrics-server will retain metrics, must set value at least 10s. (default 1m0s)
       --version                      Show version
 
-
 Kubelet client flags:
 
       --deprecated-kubelet-completely-insecure    DEPRECATED: Do not use any encryption, authorization, or authentication when communicating with the Kubelet. This is rarely the right option, since it leaves kubelet communication completely insecure.  If you encounter auth errors, make sure you've enabled token webhook auth on the Kubelet, and if you're in a test cluster with self-signed Kubelet certificates, consider using kubelet-insecure-tls instead.
@@ -19,7 +18,7 @@ Kubelet client flags:
       --kubelet-insecure-tls                      Do not verify CA of serving certificates presented by Kubelets.  For testing purposes only.
       --kubelet-port int                          The port to use to connect to Kubelets. (default 10250)
       --kubelet-preferred-address-types strings   The priority of node address types to use when determining which address to use to connect to a particular node (default [Hostname,InternalDNS,InternalIP,ExternalDNS,ExternalIP])
-      --kubelet-request-timeout duration          The timeout at request /metrics/resource endpoint of kubelet, must set value less than metric-resolution. (default 10s)
+      --kubelet-request-timeout duration          The timeout at request kubelet, must set value less than metric-resolution. (default 10s)
       --kubelet-use-node-status-port              Use the port in the node status. Takes precedence over --kubelet-port flag.
 
 Apiserver secure serving flags:

--- a/docs/command-line-flags.txt
+++ b/docs/command-line-flags.txt
@@ -9,6 +9,7 @@ Metrics server flags:
       --metric-resolution duration   The resolution at which metrics-server will retain metrics, must set value at least 10s. (default 1m0s)
       --version                      Show version
 
+
 Kubelet client flags:
 
       --deprecated-kubelet-completely-insecure    DEPRECATED: Do not use any encryption, authorization, or authentication when communicating with the Kubelet. This is rarely the right option, since it leaves kubelet communication completely insecure.  If you encounter auth errors, make sure you've enabled token webhook auth on the Kubelet, and if you're in a test cluster with self-signed Kubelet certificates, consider using kubelet-insecure-tls instead.
@@ -18,6 +19,7 @@ Kubelet client flags:
       --kubelet-insecure-tls                      Do not verify CA of serving certificates presented by Kubelets.  For testing purposes only.
       --kubelet-port int                          The port to use to connect to Kubelets. (default 10250)
       --kubelet-preferred-address-types strings   The priority of node address types to use when determining which address to use to connect to a particular node (default [Hostname,InternalDNS,InternalIP,ExternalDNS,ExternalIP])
+      --kubelet-request-timeout duration          The timeout at request /metrics/resource endpoint of kubelet, must set value less than metric-resolution. (default 10s)
       --kubelet-use-node-status-port              Use the port in the node status. Takes precedence over --kubelet-port flag.
 
 Apiserver secure serving flags:

--- a/docs/command-line-flags.txt
+++ b/docs/command-line-flags.txt
@@ -18,7 +18,7 @@ Kubelet client flags:
       --kubelet-insecure-tls                      Do not verify CA of serving certificates presented by Kubelets.  For testing purposes only.
       --kubelet-port int                          The port to use to connect to Kubelets. (default 10250)
       --kubelet-preferred-address-types strings   The priority of node address types to use when determining which address to use to connect to a particular node (default [Hostname,InternalDNS,InternalIP,ExternalDNS,ExternalIP])
-      --kubelet-request-timeout duration          The timeout at request kubelet, must set value less than metric-resolution. (default 10s)
+      --kubelet-request-timeout duration          The length of time to wait before giving up on a single request to Kubelet. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). (default 10s)
       --kubelet-use-node-status-port              Use the port in the node status. Takes precedence over --kubelet-port flag.
 
 Apiserver secure serving flags:

--- a/pkg/scraper/scraper.go
+++ b/pkg/scraper/scraper.go
@@ -133,13 +133,13 @@ func (c *scraper) Scrape(baseCtx context.Context) *storage.MetricsBatch {
 			time.Sleep(sleepDuration)
 			// make the timeout a bit shorter to account for staggering, so we still preserve
 			// the overall timeout
-			ctx, cancelTimeout := context.WithTimeout(baseCtx, c.scrapeTimeout-sleepDuration)
+			ctx, cancelTimeout := context.WithTimeout(baseCtx, c.scrapeTimeout)
 			defer cancelTimeout()
 			klog.V(2).InfoS("Scraping node", "node", klog.KObj(node))
 			m, err := c.collectNode(ctx, node)
 			if err != nil {
 				if errors.Is(err, context.DeadlineExceeded) {
-					klog.ErrorS(err, "Failed to scrape node, timeout to access kubelet", "node", klog.KObj(node), "timeout", c.scrapeTimeout-sleepDuration)
+					klog.ErrorS(err, "Failed to scrape node, timeout to access kubelet", "node", klog.KObj(node), "timeout", c.scrapeTimeout)
 				} else {
 					klog.ErrorS(err, "Failed to scrape node", "node", klog.KObj(node))
 				}


### PR DESCRIPTION
…cessing the /metrics/resource endpoint

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Optimize the timeout setting and timeout logging of metrics-server accessing the /metrics/resource endpoint
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1006

