### PR TITLE
fix: Handle error while parsing node metrics

### DIFF
--- a/pkg/scraper/client/resource/client.go
+++ b/pkg/scraper/client/resource/client.go
@@ -116,7 +116,10 @@ func (kc *kubeletClient) getMetrics(ctx context.Context, url, nodeName string) (
 		return nil, fmt.Errorf("failed to read response body - %v", err)
 	}
 	b = buf.Bytes()
-	ms := decodeBatch(b, requestTime, nodeName)
+	ms, err := decodeBatch(b, requestTime, nodeName)
 	kc.buffers.Put(b)
+	if err != nil {
+		return nil, err
+	}
 	return ms, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The change tries to handle metrics parsing errors and quit correctly, but we still need to find the root cause of Kubernetes producing incorrect metrics.

In my case, there are some metrics with zero-time in UNIX Epoch.
I'm not sure what caused this, but it looks like a zero-time metric might be generated when a Pod is shut down.
```
# HELP container_start_time_seconds [ALPHA] Start time of the container since unix epoch in seconds
# TYPE container_start_time_seconds gauge
container_start_time_seconds{container="metrics-server",namespace="kubernetes-dashboard",pod="kubernetes-dashboard-metrics-server-77db45cdf4-fppzx"} -6.7953645788713455e+09 -62135596800000
container_start_time_seconds{container="metrics-server",namespace="kubernetes-dashboard",pod="kubernetes-dashboard-metrics-server-77db45cdf4-tpx4v"} 1.6509742024191372e+09 1650974202419
```

And I think it is related to Issue #983.
When `decodeBatch` failed to parse the node metrics, it is stuck in the for loop and can't get out.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #983 

