### PR TITLE
Bring back configmap RBAC permissions

### DIFF
--- a/manifests/base/rbac.yaml
+++ b/manifests/base/rbac.yaml
@@ -59,6 +59,7 @@ rules:
     resources:
       - pods
       - nodes
+      - configmaps
     verbs:
       - get
       - list


### PR DESCRIPTION
**What this PR does / why we need it**:
This change https://github.com/kubernetes-sigs/metrics-server/commit/4a65c6aeade18c8db98b3266a663d6f7962902b5 doesn't allow to run metrics-server in a separate namespace anymore.

Bring back at least configmap permissions to allow for extension-apiserver-authentication::client-ca-file retrieval.

