### PR TITLE
fix(doc): imagePullSecrets example

### DIFF
--- a/charts/metrics-server/values.yaml
+++ b/charts/metrics-server/values.yaml
@@ -9,7 +9,7 @@ image:
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
-# - registrySecretName
+# - name: registrySecretName
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the example section for `imagePullSecrets` in values.yaml is incorrect and will cause an error 
```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.imagePullSecrets[0]): invalid type for io.k8s.api.core.v1.LocalObjectReference: got "string", expected "map"
helm.go:84: [debug] error validating "": error validating data: ValidationError(Deployment.spec.template.spec.imagePullSecrets[0]): invalid type for io.k8s.api.core.v1.LocalObjectReference: got "string", expected "map"
```
This PR improves the example and makes the chart easier to use.