### PR TITLE
Fix: Permissions to access nodes/stats API resources

### DIFF
--- a/charts/metrics-server/templates/clusterrole.yaml
+++ b/charts/metrics-server/templates/clusterrole.yaml
@@ -17,6 +17,7 @@ rules:
     resources:
       - pods
       - nodes
+      - nodes/stats
       - namespaces
       - configmaps
     verbs:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

I"ve got theses errors on metrics-server (rancher/mirrored-metrics-server:v0.5.2) on k3s :

```
E0614 18:07:30.260339       1 scraper.go:139] "Failed to scrape node" err="GET \"https://192.168.1.4:10250/stats/summary?only_cpu_and_memory=true\": bad status code \"403 Forbidden\"" node="portefaix-2"
E0614 18:07:30.269427       1 scraper.go:139] "Failed to scrape node" err="GET \"https://192.168.1.123:10250/stats/summary?only_cpu_and_memory=true\": bad status code \"403 Forbidden\"" node="portefaix-3"
E0614 18:07:30.299829       1 scraper.go:139] "Failed to scrape node" err="GET \"https://192.168.1.32:10250/stats/summary?only_cpu_and_memory=true\": bad status code \"403 Forbidden\"" node="portefaix-1"
```

It seems adding this [permissions](https://github.com/kubernetes/kubernetes/pull/105938/files) fix the problem.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

