### PR TITLE
Align RBAC between chart and kustomize

### DIFF
--- a/manifests/base/rbac.yaml
+++ b/manifests/base/rbac.yaml
@@ -59,6 +59,8 @@ rules:
     resources:
       - pods
       - nodes
+      - namespaces
+      - configmaps
     verbs:
       - get
       - list


### PR DESCRIPTION
Remove discrepency between helm chart and kustomization for RBAC where
namespace and configmap are missing. Without configmap permission
metrics-server will CrashloopBackoff

Signed-off-by: Danny Grove <danny@drgrovellc.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes issue where using release kustomize overlay causes Crashloopbackoff

