### PR TITLE
Link to PSS (since PSP is deprecated).

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The [Helm chart](https://artifacthub.io/packages/helm/metrics-server/metrics-ser
 ## Security context
 
 Metrics Server requires the `CAP_NET_BIND_SERVICE` capability in order to bind to a privileged ports as non-root.
-If you are running Metrics Server in an environment that uses PSPs or other mechanisms to restrict pod capabilities, ensure that Metrics Server is allowed
+If you are running Metrics Server in an environment that uses [PSSs](https://kubernetes.io/docs/concepts/security/pod-security-standards/) or other mechanisms to restrict pod capabilities, ensure that Metrics Server is allowed
 to use this capability.
 This applies even if you use the `--secure-port` flag to change the port that Metrics Server binds to to a non-privileged port.
 


### PR DESCRIPTION

**What this PR does / why we need it**:

It removes PSP and adds a link to PSS
