### PR TITLE
docs: point helm chart repo to metrics server github

### DIFF
--- a/index.md
+++ b/index.md
@@ -135,9 +135,8 @@ docker run --rm k8s.gcr.io/metrics-server/metrics-server:v0.5.0 --help
 
 #### Helm Chart
 
-This [Helm chart](https://github.com/helm/charts/tree/master/stable/metrics-server) can deploy the metric-server service in your cluster.
+This [Helm chart](https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server) can deploy the metric-server service in your cluster.
 
-Note: This Helm chart isn't supported by Metrics Server maintainers.
 
 ## Design
 


### PR DESCRIPTION
docs: point helm chart repo to metrics server github
Signed-off-by: ajayk <ajaykemparaj@gmail.com>

**What this PR does / why we need it**:
This Pr changes the reference of the helm chart to metrics server github instead of  the deprecated chart
