### PR TITLE
Fixup policy/v1 for k8s 1.25+

### DIFF
--- a/charts/metrics-server/templates/psp.yaml
+++ b/charts/metrics-server/templates/psp.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.rbac.pspEnabled }}
+{{- if and (.Capabilities.APIVersions.Has "policy/v1") (semverCompare ">= 1.21-0" .Capabilities.KubeVersion.Version) -}}
+apiVersion: policy/v1
+{{- else -}}
 apiVersion: policy/v1beta1
+{{- end -}}
 kind: PodSecurityPolicy
 metadata:
   name: {{ printf "privileged-%s" (include "metrics-server.fullname" .) }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Kubernetes 1.25+ have dropped `policy/v1beta1` in favor of `policy/v1`.  This patch permits running on newer systems while still allowing older hosts to install the chart.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: #1104
