### PR TITLE
try to fix e2e test failure

### DIFF
--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -535,6 +535,12 @@ func consumeCPU(client clientset.Interface, podName string) error {
 					Requests: map[corev1.ResourceName]resource.Quantity{
 						corev1.ResourceCPU: mustQuantity("100m"),
 					},
+					// TODO: Need continue to investigate the issue of inaccurate cpu utilization caused by not adding the limits,
+					// and will revmoe the limits eventually
+					// For analysis, see https://github.com/kubernetes-sigs/metrics-server/pull/1119
+					Limits: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceCPU: mustQuantity("100m"),
+					},
 				},
 			},
 		}},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The pull-metrics-server-test-e2e and pull-metrics-server-test-e2e-ha tests have failed frequently  recently because the test case `returns accurate CPU metric` fails.
The most likely reason is that when the pod is just successfully deployed, the metrics obtained are inaccurate. We need to wait for one scrape cycle

https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-metrics-server-test-e2e
https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-metrics-server-test-e2e-ha

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

