### PR TITLE
cloudbuild: remove buildx-specific commands

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,11 +4,9 @@ options:
   substitution_option: ALLOW_LOOSE
 steps:
   - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90'
+    entrypoint: make
     env:
     - GIT_TAG=$_PULL_BASE_REF
     - GIT_COMMIT=$_PULL_BASE_SHA
     args:
-    - "-c"
-    # GCB creates a separate home directory, so need to link to root .docker dir
-    # in order for docker-buildx plugin to work.
-    - "ln -s /root/.docker/cli-plugins ~/.docker/cli-plugins && make push-all"
+    - push-all


### PR DESCRIPTION
We are not using buildx to build images anymore so it is safe to cleanup the code that was written to support it.