### PR TITLE
Update v0.6.x compatibility with Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Installation instructions for previous releases can be found in [Metrics Server 
 
 Metrics Server | Metrics API group/version | Supported Kubernetes version
 ---------------|---------------------------|-----------------------------
-0.6.x          | `metrics.k8s.io/v1beta1`  | 1.19+
+0.6.x          | `metrics.k8s.io/v1beta1`  | 1.19-1.24
 0.5.x          | `metrics.k8s.io/v1beta1`  | *1.8+
 0.4.x          | `metrics.k8s.io/v1beta1`  | *1.8+
 0.3.x          | `metrics.k8s.io/v1beta1`  | 1.8-1.21


### PR DESCRIPTION
The high-availability manifests that are shipped with metrics-server contain a PDB configuration. This one is currently using the `policy/v1beta1` version of the API which will is removed in Kubernetes 1.25. The problem is that the replacement for it is the `policy/v1` API that was introduced in 1.21, so if we want to continue supporting Kubernetes 1.19 and 1.20 on the 0.6 minor, we need to limit the support range to 1.19-1.24.