### PR TITLE
Add HA manifests compatible with 1.25+ to release-0.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ release-manifests:
 	mkdir -p _output
 	kubectl kustomize manifests/release > _output/components.yaml
 	kubectl kustomize manifests/high-availability > _output/high-availability.yaml
+	kubectl kustomize manifests/high-availability-1.25+ > _output/high-availability-1.25+.yaml
 
 # Unit tests
 # ----------

--- a/manifests/high-availability-1.25+/kustomization.yaml
+++ b/manifests/high-availability-1.25+/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../high-availability
+patches:
+- path: patch-pdb-version.yaml
+  target:
+    kind: PodDisruptionBudget

--- a/manifests/high-availability-1.25+/patch-pdb-version.yaml
+++ b/manifests/high-availability-1.25+/patch-pdb-version.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: "/apiVersion"
+  value: policy/v1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The policy/v1beta1 API version is removed in Kubernetes 1.25 in favor of policy/v1.

This is a follow-up to the discussion in https://github.com/kubernetes-sigs/metrics-server/pull/1134 which resulted in an agreement to publish multiple versions of manifests when needed for wider support purposes.
