### PR TITLE
Add HA manifests for the different compatibilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ release-manifests:
 	mkdir -p _output
 	kubectl kustomize manifests/overlays/release > _output/components.yaml
 	kubectl kustomize manifests/overlays/release-ha > _output/high-availability.yaml
+	kubectl kustomize manifests/overlays/release-ha-1.21+ > _output/high-availability-1.21+.yaml
 
 
 # fuzz tests

--- a/manifests/components/high-availability-1.21+/kustomization.yaml
+++ b/manifests/components/high-availability-1.21+/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+components:
+- ../high-availability
+patches:
+- path: patch-pdb-version.yaml
+  target:
+    kind: PodDisruptionBudget

--- a/manifests/components/high-availability-1.21+/patch-pdb-version.yaml
+++ b/manifests/components/high-availability-1.21+/patch-pdb-version.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: "/apiVersion"
+  value: policy/v1

--- a/manifests/components/high-availability/pdb.yaml
+++ b/manifests/components/high-availability/pdb.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: metrics-server

--- a/manifests/overlays/release-ha-1.21+/kustomization.yaml
+++ b/manifests/overlays/release-ha-1.21+/kustomization.yaml
@@ -4,4 +4,4 @@ resources:
 - ../../base
 components:
 - ../../components/high-availability-1.21+
-- ../../components/test
+- ../../components/release


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Going forward, we will use the high-availability component as the base to build compatible configurations on top. Then each change impacting compatibility will have to introduce a new component that will patch the main one.

This is done to make sure that we keep the same assets semantic across versions and that we do not make incompatible changes that would break compatibility with older versions of Kubernetes.

