### PR TITLE
Update HA instructions to include 1.21+ deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Metrics Server | Metrics API group/version | Supported Kubernetes version
 
 Metrics Server can be installed in high availability mode directly from a YAML manifest or via the official [Helm chart](https://artifacthub.io/packages/helm/metrics-server/metrics-server) by setting the `replicas` value greater than `1`. To install the latest Metrics Server release in high availability mode from the  _high-availability.yaml_ manifest, run the following command.
 
+On Kubernetes v1.21+:
+```
+kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/high-availability-1.21+.yaml
+```
+
+On Kubernetes v1.19-1.21:
 ```shell
 kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/high-availability.yaml
 ```


### PR DESCRIPTION
Documentation bits for https://github.com/kubernetes-sigs/metrics-server/pull/1139.
