### PR TITLE
golangci-lint: fix goimports & add staticcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -23,14 +22,12 @@ linters:
     - misspell
     - nakedret
     - nolintlint
-    - rowserrcheck
-    - structcheck
+    - staticcheck
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - whitespace
 
 linters-settings:
   goimports:
-local-prefixes: sigs.k8s.io/metrics-server
+    local-prefixes: sigs.k8s.io/metrics-server

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,12 @@ BUILD_DATE:=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 ALL_ARCHITECTURES=amd64 arm arm64 ppc64le s390x
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
+# Tools versions
+# --------------
+GOLANGCI_VERSION:=1.50.1
+
 # Computed variables
 # ------------------
-HAS_GOLANGCI:=$(shell which golangci-lint)
 GOPATH:=$(shell go env GOPATH)
 REPO_DIR:=$(shell pwd)
 LDFLAGS=-w $(VERSION_LDFLAGS)
@@ -213,17 +216,17 @@ endif
 
 .PHONY: verify-lint
 verify-lint: golangci
-	golangci-lint run --timeout 10m --modules-download-mode=readonly || (echo 'Run "make update"' && exit 1)
+	$(GOPATH)/bin/golangci-lint run --timeout 10m --modules-download-mode=readonly || (echo 'Run "make update"' && exit 1)
 
 .PHONY: update-lint
 update-lint: golangci
-	golangci-lint run --fix --modules-download-mode=readonly
+	$(GOPATH)/bin/golangci-lint run --fix --modules-download-mode=readonly
 
-HAS_GOLANGCI:=$(shell which golangci-lint)
+HAS_GOLANGCI_VERSION:=$(shell $(GOPATH)/bin/golangci-lint version --format=short)
 .PHONY: golangci
 golangci:
-ifndef HAS_GOLANGCI
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.48.0
+ifneq ($(HAS_GOLANGCI_VERSION), $(GOLANGCI_VERSION))
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v$(GOLANGCI_VERSION)
 endif
 
 # Table of Contents

--- a/cmd/metrics-server/app/options/kubelet_client.go
+++ b/cmd/metrics-server/app/options/kubelet_client.go
@@ -17,13 +17,12 @@ import (
 	"fmt"
 	"time"
 
-	"sigs.k8s.io/metrics-server/pkg/scraper/client"
-
 	"github.com/spf13/pflag"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 
+	"sigs.k8s.io/metrics-server/pkg/scraper/client"
 	"sigs.k8s.io/metrics-server/pkg/utils"
 )
 

--- a/cmd/metrics-server/app/options/kubelet_client_test.go
+++ b/cmd/metrics-server/app/options/kubelet_client_test.go
@@ -17,11 +17,12 @@ import (
 	"testing"
 	"time"
 
-	"sigs.k8s.io/metrics-server/pkg/scraper/client"
-
 	"github.com/google/go-cmp/cmp"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
+
+	"sigs.k8s.io/metrics-server/pkg/scraper/client"
 )
 
 func TestConfig(t *testing.T) {

--- a/cmd/metrics-server/app/options/options.go
+++ b/cmd/metrics-server/app/options/options.go
@@ -28,11 +28,11 @@ import (
 	"k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 	logsapi "k8s.io/component-base/logs/api/v1"
+	_ "k8s.io/component-base/logs/json/register"
+
 	"sigs.k8s.io/metrics-server/pkg/api"
 	generatedopenapi "sigs.k8s.io/metrics-server/pkg/api/generated/openapi"
 	"sigs.k8s.io/metrics-server/pkg/server"
-
-	_ "k8s.io/component-base/logs/json/register"
 )
 
 type Options struct {

--- a/cmd/metrics-server/app/start.go
+++ b/cmd/metrics-server/app/start.go
@@ -22,10 +22,10 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/client-go/pkg/version"
-
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 	"k8s.io/component-base/term"
+
 	"sigs.k8s.io/metrics-server/cmd/metrics-server/app/options"
 )
 

--- a/pkg/api/node.go
+++ b/pkg/api/node.go
@@ -137,11 +137,11 @@ func (m *nodeMetrics) ConvertToTable(ctx context.Context, object runtime.Object,
 	switch t := object.(type) {
 	case *metrics.NodeMetrics:
 		table.ResourceVersion = t.ResourceVersion
-		table.SelfLink = t.SelfLink
+		table.SelfLink = t.SelfLink //nolint:staticcheck // keep deprecated field to be backward compatible
 		addNodeMetricsToTable(&table, *t)
 	case *metrics.NodeMetricsList:
 		table.ResourceVersion = t.ResourceVersion
-		table.SelfLink = t.SelfLink
+		table.SelfLink = t.SelfLink //nolint:staticcheck // keep deprecated field to be backward compatible
 		table.Continue = t.Continue
 		addNodeMetricsToTable(&table, t.Items...)
 	default:

--- a/pkg/api/pod.go
+++ b/pkg/api/pod.go
@@ -143,11 +143,11 @@ func (m *podMetrics) ConvertToTable(ctx context.Context, object runtime.Object, 
 	switch t := object.(type) {
 	case *metrics.PodMetrics:
 		table.ResourceVersion = t.ResourceVersion
-		table.SelfLink = t.SelfLink
+		table.SelfLink = t.SelfLink //nolint:staticcheck // keep deprecated field to be backward compatible
 		addPodMetricsToTable(&table, *t)
 	case *metrics.PodMetricsList:
 		table.ResourceVersion = t.ResourceVersion
-		table.SelfLink = t.SelfLink
+		table.SelfLink = t.SelfLink //nolint:staticcheck // keep deprecated field to be backward compatible
 		table.Continue = t.Continue
 		addPodMetricsToTable(&table, t.Items...)
 	default:

--- a/pkg/scraper/client/interface.go
+++ b/pkg/scraper/client/interface.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	v1 "k8s.io/api/core/v1"
+
 	"sigs.k8s.io/metrics-server/pkg/storage"
 )
 

--- a/pkg/scraper/client/resource/client.go
+++ b/pkg/scraper/client/resource/client.go
@@ -19,20 +19,19 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"sync"
-	"time"
-
 	"net"
 	"net/http"
 	"net/url"
 	"strconv"
+	"sync"
+	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
+
 	"sigs.k8s.io/metrics-server/pkg/scraper/client"
 	"sigs.k8s.io/metrics-server/pkg/storage"
 	"sigs.k8s.io/metrics-server/pkg/utils"
-
-	corev1 "k8s.io/api/core/v1"
 )
 
 type kubeletClient struct {
@@ -93,6 +92,7 @@ func (kc *kubeletClient) GetMetrics(ctx context.Context, node *corev1.Node) (*st
 	return kc.getMetrics(ctx, url.String(), node.Name)
 }
 
+//nolint:staticcheck // to disable SA6002 (argument should be pointer-like to avoid allocations)
 func (kc *kubeletClient) getMetrics(ctx context.Context, url, nodeName string) (*storage.MetricsBatch, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/pkg/scraper/client/resource/decode.go
+++ b/pkg/scraper/client/resource/decode.go
@@ -22,8 +22,10 @@ import (
 
 	"github.com/prometheus/prometheus/model/textparse"
 	"github.com/prometheus/prometheus/model/timestamp"
+
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+
 	"sigs.k8s.io/metrics-server/pkg/storage"
 )
 

--- a/pkg/scraper/client/resource/decode_test.go
+++ b/pkg/scraper/client/resource/decode_test.go
@@ -20,7 +20,9 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	apitypes "k8s.io/apimachinery/pkg/types"
+
 	"sigs.k8s.io/metrics-server/pkg/storage"
 )
 
@@ -244,7 +246,7 @@ container_start_time_seconds{container="metrics-server",namespace="kubernetes-da
 }
 
 func Fuzz_decodeBatchPrometheusFormat(f *testing.F) {
-	testSeedsFloat64 := []float64{0, -10000, 10000, 0.5, -0.000000001, -0.0, 1e100, -1e100}
+	testSeedsFloat64 := []float64{0, -10000, 10000, 0.5, -0.000000001, 1e100, -1e100}
 	testSeedsInt64 := []int64{0, -10000, 10000, 5, -1, -0}
 	testSeedsString := []string{"abc", "ABC", "Abc", "_ab", "-ab", "!@~#$%^&*()[]{}\"',.?/\\`"}
 	for _, seedFloat64 := range testSeedsFloat64 {

--- a/pkg/scraper/scraper.go
+++ b/pkg/scraper/scraper.go
@@ -20,8 +20,6 @@ import (
 	"math/rand"
 	"time"
 
-	"sigs.k8s.io/metrics-server/pkg/scraper/client"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	apitypes "k8s.io/apimachinery/pkg/types"
@@ -29,6 +27,7 @@ import (
 	"k8s.io/component-base/metrics"
 	"k8s.io/klog/v2"
 
+	"sigs.k8s.io/metrics-server/pkg/scraper/client"
 	"sigs.k8s.io/metrics-server/pkg/storage"
 )
 

--- a/pkg/scraper/scraper_test.go
+++ b/pkg/scraper/scraper_test.go
@@ -21,8 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"sigs.k8s.io/metrics-server/pkg/scraper/client"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -32,6 +30,7 @@ import (
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-base/metrics/testutil"
 
+	"sigs.k8s.io/metrics-server/pkg/scraper/client"
 	"sigs.k8s.io/metrics-server/pkg/storage"
 )
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -18,20 +18,18 @@ import (
 	"net/http"
 	"time"
 
-	"sigs.k8s.io/metrics-server/pkg/scraper/client"
-	"sigs.k8s.io/metrics-server/pkg/scraper/client/resource"
-
 	corev1 "k8s.io/api/core/v1"
 	apimetrics "k8s.io/apiserver/pkg/endpoints/metrics"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/rest"
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
-
 	_ "k8s.io/component-base/metrics/prometheus/restclient" // for client-go metrics registration
 
 	"sigs.k8s.io/metrics-server/pkg/api"
 	"sigs.k8s.io/metrics-server/pkg/scraper"
+	"sigs.k8s.io/metrics-server/pkg/scraper/client"
+	"sigs.k8s.io/metrics-server/pkg/scraper/client/resource"
 	"sigs.k8s.io/metrics-server/pkg/storage"
 )
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -20,15 +20,15 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/metrics/pkg/apis/metrics"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/metrics/pkg/apis/metrics"
+
 	"sigs.k8s.io/metrics-server/pkg/scraper"
 	"sigs.k8s.io/metrics-server/pkg/storage"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 func TestServer(t *testing.T) {

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -20,11 +20,11 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/metrics-server/pkg/api"
 
-	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/metrics-server/pkg/api"
 )
 
 // MetricsBatch is a single batch of pod, container, and node metrics from some source.

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sort"
@@ -27,15 +27,13 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
-
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/common/expfmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	clientset "k8s.io/client-go/kubernetes"
@@ -44,6 +42,7 @@ import (
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport"
 	"k8s.io/client-go/transport/spdy"
+	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
 )
 
@@ -432,7 +431,7 @@ func proxyRequestToPod(config *rest.Config, namespace, podname, scheme string, p
 		return nil, err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -440,7 +439,7 @@ func proxyRequestToPod(config *rest.Config, namespace, podname, scheme string, p
 }
 
 func setupForwarding(config *rest.Config, namespace, podname string, port int) (cancel func(), err error) {
-	hostIP := strings.TrimLeft(config.Host, "https://")
+	hostIP := strings.TrimPrefix(config.Host, "https://")
 	mappings := []string{fmt.Sprintf("%d:%d", localPort, port)}
 
 	trans, upgrader, err := spdy.RoundTripperFor(config)


### PR DESCRIPTION
This PR brings 3 commits related to golangci-lint:

1. Fix `goimports` configuration (`.golangci.yml` had an indentation issue) and re-order imports;
2. Update golangci-lint:
   - Bump golangci-lint to its latest version (`1.50.1`)
   - Remove linters `deadcode`, `structcheck` and `varcheck`, deprecated by golangci-lint since version `1.49.0` (because they were unmaintained)
   - Remove linter `rowserrcheck`, which is disabled by golangci-lint because it's not compatible with Go generics, and which is not useful for metrics-server as it only checks errors in `sql.Rows`
   - Add linter `staticcheck`
3. Fix `staticcheck` errors