### PR TITLE
fix(ha/podAntiAffinity): instead of using 'requiredDuringSchedulingIg…

### DIFF
--- a/manifests/components/high-availability/patch.yaml
+++ b/manifests/components/high-availability/patch.yaml
@@ -13,10 +13,15 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                k8s-app: metrics-server
-            namespaces:
-            - kube-system
-            topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: k8s-app
+                  operator: In
+                  values:
+                  - metrics-server
+              topologyKey: kubernetes.io/hostname
+              namespaces:
+              - kube-system


### PR DESCRIPTION
Signed-off-by: Ugur Can Ozturk [ugurozturk918@gmail.com](mailto:ugurozturk918@gmail.com)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Instead of using `requiredDuringSchedulingIgnoredDuringExecution` which enforces the metrics_server pods run different nodes, I believe that we can use `preferredDuringSchedulingIgnoredDuringExecution` which prioritizes the running pods on different nodes. Also, it can help to enable HA mode on the small but heavy traffic load clusters. Apart from that, if there are points I missed, I would like to hear them. Thank you.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

