### PR TITLE
Publish high-availability-1.21+ manifest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,3 +19,4 @@ jobs:
           files: |
             _output/components.yaml
             _output/high-availability.yaml
+            _output/high-availability-1.21+.yaml


### PR DESCRIPTION
I completely forgot that we automated publishing the manifests and forgot to add the new one. At least I added it manually when I released v0.6.2 to all the v0.6.x releases, but we should have that automated.

Once merged, I will backport to release-0.6 in case we release a new patch version in the feature.
