### PR TITLE
Remove manual assets publication step from RELEASE.md 

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,6 @@ The Metrics Server is released on an as-needed basis. The process is as follows:
 1. An OWNER creates a draft GitHub release
 1. An OWNER creates an issue to release the corresponding Helm chart via the chart release process (below)
 1. An OWNER creates a release tag using `GIT_TAG=$VERSION make release-tag` and waits for [prow.k8s.io](prow.k8s.io) to build and push new images to [gcr.io/k8s-staging-metrics-server](https://gcr.io/k8s-staging-metrics-server)
-1. An OWNER builds the release manifests using `make release-manifests` and uploads them to Github release
 1. A PR in [kubernetes/k8s.io](https://github.com/kubernetes/k8s.io/blob/main/k8s.gcr.io/images/k8s-staging-metrics-server/images.yaml) is created to release images to `k8s.gcr.io`
 1. An OWNER publishes the GitHub release. Once published, release manifests will be automatically added to the release by CI.
 1. An announcement email is sent to `kubernetes-sig-instrumentation@googlegroups.com` with the subject `[ANNOUNCE] metrics-server $VERSION is released`


### PR DESCRIPTION
We now have an automated github action that uploads the assets when a release is published so we don't need to do it manually anymore.