### PR TITLE
[release-0.6] Publish high-availability-1.21+ manifest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,3 +19,4 @@ jobs:
           files: |
             _output/components.yaml
             _output/high-availability.yaml
+            _output/high-availability-1.21+.yaml


### PR DESCRIPTION
Backport of https://github.com/kubernetes-sigs/metrics-server/pull/1149 to release-0.6.