### PR TITLE
e2e test adds support for kubernetes version 1.26

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,10 +148,14 @@ test-image-all:
 # -----------
 
 .PHONY: test-e2e
-test-e2e: test-e2e-1.25
+test-e2e: test-e2e-1.26
 
 .PHONY: test-e2e-all
-test-e2e-all: test-e2e-1.25 test-e2e-1.24 test-e2e-1.23
+test-e2e-all: test-e2e-1.26 test-e2e-1.25 test-e2e-1.24
+
+.PHONY: test-e2e-1.26
+test-e2e-1.26:
+	NODE_IMAGE=kindest/node:v1.26.0@sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352 ./test/test-e2e.sh
 
 .PHONY: test-e2e-1.25
 test-e2e-1.25:
@@ -160,10 +164,6 @@ test-e2e-1.25:
 .PHONY: test-e2e-1.24
 test-e2e-1.24:
 	NODE_IMAGE=kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315 ./test/test-e2e.sh
-
-.PHONY: test-e2e-1.23
-test-e2e-1.23:
-	NODE_IMAGE=kindest/node:v1.23.13@sha256:ef453bb7c79f0e3caba88d2067d4196f427794086a7d0df8df4f019d5e336b61 ./test/test-e2e.sh
 
 .PHONY: test-e2e-ha
 test-e2e-ha:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
kubernetes version 1.26 has been released. e2e test adds support for version 1.26
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

