### PR TITLE
cleanup: remove package for new go version

### DIFF
--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sort"
@@ -432,7 +432,7 @@ func proxyRequestToPod(config *rest.Config, namespace, podname, scheme string, p
 		return nil, err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
The io/ioutil package has been deprecated from go 1.16: https://go.dev/doc/go1.16#ioutil

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

