### PR TITLE
Stop tagging helm chart releases as "latest"

### DIFF
--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -72,20 +72,3 @@ jobs:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_RELEASE_NAME_TEMPLATE: "metrics-server-helm-chart-{{ .Version }}"
           CR_MAKE_RELEASE_LATEST: false
-
-      - name: Download release
-        if: fromJSON(steps.check_can_release.outputs.continue)
-        uses: robinraju/release-downloader@768b85c8d69164800db5fc00337ab917daf3ce68 # v1.7
-        with:
-          repository: "kubernetes-sigs/metrics-server"
-          tag: "v${{ steps.chart_app_version.outputs.result }}"
-          fileName: "*"
-
-      - name: Update release
-        if: fromJSON(steps.check_can_release.outputs.continue)
-        uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e # v1.12.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: "metrics-server-helm-chart-${{ steps.chart_version.outputs.result }}"
-          allowUpdates: true
-          artifacts: "components.yaml,high-availability.yaml"

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -71,6 +71,7 @@ jobs:
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_RELEASE_NAME_TEMPLATE: "metrics-server-helm-chart-{{ .Version }}"
+          CR_MAKE_RELEASE_LATEST: false
 
       - name: Download release
         if: fromJSON(steps.check_can_release.outputs.continue)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

We used to publish metrics-server's assets alongside the helm chart
although they are not useful to it because the helm chart release was
tagged as "latest" and so if we wanted users to get the latest assets we
needed to copy them to the helm release. Since helm releases are not
tagged as latest anymore, it is not necessary do continue doing that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #1173 

