### PR TITLE
Optimize e2e tests

### DIFF
--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -519,13 +519,13 @@ func watchPodReadyStatus(client clientset.Interface, podNamespace string, podNam
 			if !ok {
 				return fmt.Errorf("Watch pod failed")
 			}
-			var containerReady = false
-			if pod.Name == podName {
+			var containerReady = true
+			if pod.Name == podName && len(pod.Status.ContainerStatuses) != 0 {
 				for _, containerStatus := range pod.Status.ContainerStatuses {
 					if !containerStatus.Ready {
+						containerReady = false
 						break
 					}
-					containerReady = true
 				}
 				if containerReady {
 					return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The logic of detecting whether the containers are ready is a bit issue. need optimize.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

