### PR TITLE
chore: Fixed GH workflow approval

### DIFF
--- a/.github/workflows/gh-workflow-approve.yaml
+++ b/.github/workflows/gh-workflow-approve.yaml
@@ -18,20 +18,21 @@ jobs:
     steps:
       - name: Update PR
         uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # v6.3.3
+        continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           debug: ${{ secrets.ACTIONS_RUNNER_DEBUG }}
           script: |
-            const workflowRuns = await github.rest.actions.listWorkflowRunsForRepo({
+            const result = await github.rest.actions.listWorkflowRunsForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
               event: "pull_request",
               status: "action_required",
-              head_sha: context.sha,
+              head_sha: context.payload.pull_request.head.sha,
               per_page: 100
-            }).data.workflow_runs;
+            });
 
-            for (var run of workflowRuns) {
+            for (var run of result.data.workflow_runs) {
               await github.rest.actions.approveWorkflowRun({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR fixes the GH Workflow approval action which I previously added. I have debugged why this was working correctly on my CLI but not in the action and I have run it in a test repo to prove that it functioning correctly without errors.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

