### PR TITLE
Changed the registry location to registry.k8s.io

### DIFF
--- a/.github/workflows/lint-test-chart.yaml
+++ b/.github/workflows/lint-test-chart.yaml
@@ -7,43 +7,66 @@ on:
 
 jobs:
   lint-test:
+    name: Lint & Test
     if: github.repository == 'kubernetes-sigs/metrics-server'
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
         with:
           fetch-depth: 0
 
-      - name: Set up Helm
-        uses: azure/setup-helm@v1
+      - name: Set-up Python
+        uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912 # v4.4.0
         with:
-          version: 3.*
+          python-version: "3.x"
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - name: Set-up Helm
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
         with:
-          python-version: 3.7
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
 
-      - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.1.0
-
-      - name: Run chart-testing (list-changed)
-        id: list-changed
+      - name: Set-up Artifact Hub CLI
         run: |
-          changed=$(ct list-changed)
-          if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+          set -euo pipefail
+          curl -Lo /tmp/ah.tar.gz https://github.com/artifacthub/hub/releases/download/v1.11.0/ah_1.11.0_linux_amd64.tar.gz
+          tar -xzvf /tmp/ah.tar.gz --directory /tmp
+          mv /tmp/ah /usr/local/bin/ah
+          chmod +x /usr/local/bin/ah
+          rm -f /tmp/ah.tar.gz
+
+      - name: Set-up chart-testing
+        uses: helm/chart-testing-action@afea100a513515fbd68b0e72a7bb0ae34cb62aec # v2.3.1
+
+      - name: Check for changes
+        id: changes
+        run: |
+          changed="$(ct list-changed)"
+          if [[ -n "${changed}" ]]
+          then
+            echo "changed=${{ toJSON(true) }}" >> $GITHUB_OUTPUT
+          else
+            echo "changed=${{ toJSON(false) }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Run chart-testing (lint)
+      - name: Run Artifact Hub lint
+        if: fromJSON(steps.changes.outputs.changed)
+        run: ah lint --kind helm || exit 1
+
+      - name: Run chart-testing lint
+        if: fromJSON(steps.changes.outputs.changed)
         run: ct lint --check-version-increment=false
 
       - name: Create Kind cluster
-        uses: helm/kind-action@v1.2.0
+        if: fromJSON(steps.changes.outputs.changed)
+        uses: helm/kind-action@d8ccf8fb623ce1bb360ae2f45f323d9d5c5e9f00 # v1.5.0
         with:
           wait: 120s
-        if: steps.list-changed.outputs.changed == 'true'
 
-      - name: Run chart-testing (install)
+      - name: Run chart-testing install
+        if: fromJSON(steps.changes.outputs.changed)
         run: ct install

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -9,11 +9,15 @@ on:
 
 jobs:
   release:
+    name: Release
     if: github.repository == 'kubernetes-sigs/metrics-server'
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
         with:
           fetch-depth: 0
 
@@ -24,19 +28,18 @@ jobs:
 
       - name: Get chart version
         id: chart_version
-        uses: mikefarah/yq@v4.19.1
+        uses: mikefarah/yq@87cba2ecbeaecf860efcceb66deab46ae030ce1e # v4.30.6
         with:
           cmd: yq eval '.version' './charts/metrics-server/Chart.yaml'
 
       - name: Get chart app version
         id: chart_app_version
-        uses: mikefarah/yq@v4.19.1
+        uses: mikefarah/yq@87cba2ecbeaecf860efcceb66deab46ae030ce1e # v4.30.6
         with:
           cmd: yq eval '.appVersion' './charts/metrics-server/Chart.yaml'
 
       - name: Check can release
         id: check_can_release
-        shell: bash
         run: |
           set -euo pipefail
 
@@ -50,36 +53,22 @@ jobs:
 
           if [[ -z "${chart_version_match}" ]] || [[ -z "${app_version_match}" ]]
           then
-            echo "::set-output name=continue::${{ toJSON(false) }}"
+            echo "continue=${{ toJSON(false) }}" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=continue::${{ toJSON(true) }}"
+            echo "continue=${{ toJSON(true) }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Install Helm
+      - name: Set-up Helm
         if: fromJSON(steps.check_can_release.outputs.continue)
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
         with:
-          version: 3.*
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
 
       - name: Run chart-releaser
         if: fromJSON(steps.check_can_release.outputs.continue)
-        uses: helm/chart-releaser-action@v1.3.0
+        uses: helm/chart-releaser-action@be16258da8010256c6e82849661221415f031968 # v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_RELEASE_NAME_TEMPLATE: "metrics-server-helm-chart-{{ .Version }}"
-
-      - uses: robinraju/release-downloader@v1.3
-        if: fromJSON(steps.check_can_release.outputs.continue)
-        with:
-          repository: "kubernetes-sigs/metrics-server"
-          tag: "v${{ steps.chart_app_version.outputs.result }}"
-          fileName: "*"
-
-      - name: Update release
-        if: fromJSON(steps.check_can_release.outputs.continue)
-        uses: ncipollo/release-action@v1
-        with:
-          tag: "metrics-server-helm-chart-${{ steps.chart_version.outputs.result }}"
-          allowUpdates: true
-          artifacts: "components.yaml,high-availability.yaml"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          CR_MAKE_RELEASE_LATEST: false

--- a/charts/metrics-server/Chart.yaml
+++ b/charts/metrics-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metrics-server
 description: Metrics Server is a scalable, efficient source of container resource metrics for Kubernetes built-in autoscaling pipelines.
 type: application
-version: 3.8.3
+version: 3.8.4
 appVersion: 0.6.2
 keywords:
   - kubernetes
@@ -21,17 +21,5 @@ maintainers:
     url: https://github.com/endrec
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "Added support for topologySpreadConstraints."
-    - kind: added
-      description: "Set resource namespaces explicitly."
-    - kind: added
-      description: "Allow configuring TLS on the APIService."
-    - kind: added
-      description: "Enabled service monitor relabelling."
-    - kind: added
-      description: "Added ability to set the scheduler name."
-    - kind: added
-      description: "Added support for common labels."
     - kind: changed
-      description: "Updated Metrics Server image to v0.6.2."
+      description: "Changed the image registry location to registry.k8s.io."

--- a/charts/metrics-server/values.yaml
+++ b/charts/metrics-server/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: k8s.gcr.io/metrics-server/metrics-server
+  repository: registry.k8s.io/metrics-server/metrics-server
   # Overrides the image tag whose default is v{{ .Chart.AppVersion }}
   tag: ""
   pullPolicy: IfNotPresent


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR updates the image registry location from `k8s.gcr.io` to `registry.k8s.io`, it also updates the chart tooling to what's currently on `master`. By doing this release we're allowing the release of `v0.7.0` to be unlinked from supporting the new registry (see #1165).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


