### PR TITLE
Helm: Fix addon resizer role and configMap

### DIFF
--- a/charts/metrics-server/Chart.yaml
+++ b/charts/metrics-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metrics-server
 description: Metrics Server is a scalable, efficient source of container resource metrics for Kubernetes built-in autoscaling pipelines.
 type: application
-version: 3.9.1
+version: 3.9.0
 appVersion: 0.6.3
 keywords:
   - kubernetes

--- a/charts/metrics-server/Chart.yaml
+++ b/charts/metrics-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: metrics-server
 description: Metrics Server is a scalable, efficient source of container resource metrics for Kubernetes built-in autoscaling pipelines.
 type: application
-version: 3.9.0
+version: 3.9.1
 appVersion: 0.6.3
 keywords:
   - kubernetes

--- a/charts/metrics-server/templates/_helpers.tpl
+++ b/charts/metrics-server/templates/_helpers.tpl
@@ -85,6 +85,13 @@ ConfigMap name of addon resizer
 {{- printf "%s-%s" (include "metrics-server.fullname" .) "nanny-config" }}
 {{- end }}
 
+{{/*
+Role name of addon resizer
+*/}}
+{{- define "metrics-server.addonResizer.role" -}}
+{{ printf "system:%s-nanny" (include "metrics-server.fullname" .) }}
+{{- end }}
+
 {{/* Get PodDisruptionBudget API Version */}}
 {{- define "metrics-server.pdb.apiVersion" -}}
   {{- if and (.Capabilities.APIVersions.Has "policy/v1") (semverCompare ">= 1.21-0" .Capabilities.KubeVersion.Version) -}}

--- a/charts/metrics-server/templates/_helpers.tpl
+++ b/charts/metrics-server/templates/_helpers.tpl
@@ -78,6 +78,13 @@ The image to use for the addon resizer
 {{- printf "%s:%s" .Values.addonResizer.image.repository .Values.addonResizer.image.tag }}
 {{- end }}
 
+{{/*
+ConfigMap name of addon resizer
+*/}}
+{{- define "metrics-server.addonResizer.configMap" -}}
+{{- printf "%s-%s" (include "metrics-server.fullname" .) "nanny-config" }}
+{{- end }}
+
 {{/* Get PodDisruptionBudget API Version */}}
 {{- define "metrics-server.pdb.apiVersion" -}}
   {{- if and (.Capabilities.APIVersions.Has "policy/v1") (semverCompare ">= 1.21-0" .Capabilities.KubeVersion.Version) -}}

--- a/charts/metrics-server/templates/configmaps-nanny.yaml
+++ b/charts/metrics-server/templates/configmaps-nanny.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "metrics-server.fullname" .}}-nanny-config
+  name: {{ include "metrics-server.addonResizer.configMap" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "metrics-server.labels" . | nindent 4 }}

--- a/charts/metrics-server/templates/deployment.yaml
+++ b/charts/metrics-server/templates/deployment.yaml
@@ -121,6 +121,11 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
+      {{- if .Values.addonResizer.enabled }}
+        - name: nanny-config-volume
+          configMap:
+            name: {{ include "metrics-server.addonResizer.configMap" . }}
+      {{- end }}
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/metrics-server/templates/role-nanny.yaml
+++ b/charts/metrics-server/templates/role-nanny.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ printf "system:%s-nanny" (include "metrics-server.fullname" .) }}
+  name: {{ include "metrics-server.addonResizer.role" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "metrics-server.labels" . | nindent 4 }}
@@ -19,7 +19,7 @@ rules:
   resources:
   - deployments
   resourceNames:
-  - metrics-server
+  - {{ include "metrics-server.fullname" . }}
   verbs:
   - get
   - patch

--- a/charts/metrics-server/templates/rolebinding-nanny.yaml
+++ b/charts/metrics-server/templates/rolebinding-nanny.yaml
@@ -10,7 +10,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: metrics-server-nanny
+  name: {{ include "metrics-server.addonResizer.role" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "metrics-server.serviceAccountName" . }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: 

- The nanny-config-volume is not in the deployment volumes, causing an error on deployment
- The name of the nanny role in the rolebinding is incorrect. It is missing the `system:` prefix
- Both resource names were created in helpers.tpl


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # N/A

