### PR TITLE
include common labels in pod labels

### DIFF
--- a/charts/metrics-server/templates/deployment.yaml
+++ b/charts/metrics-server/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "metrics-server.selectorLabels" . | nindent 8 }}
+        {{- include "metrics-server.labels" . | nindent 8 }}
       {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
- adds all common labels to metadata labels in the pod spec. The main reasoning is to persist the `helm.sh/chart`,  `app.kubernetes.io/version` and `app.kubernetes.io/managed-by` labels to the pod for standardisation. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

