### PR TITLE
Fix: Incorporate `-w` into `LDFLAGS`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,10 @@ all: metrics-server
 SRC_DEPS=$(shell find pkg cmd -type f -name "*.go") go.mod go.sum
 CHECKSUM=$(shell md5sum $(SRC_DEPS) | md5sum | awk '{print $$1}')
 PKG:=k8s.io/client-go/pkg
-LDFLAGS:=-X $(PKG)/version.gitVersion=$(GIT_TAG) -X $(PKG)/version.gitCommit=$(GIT_COMMIT) -X $(PKG)/version.buildDate=$(BUILD_DATE)
+# This variable is included into LDFLAGS above based on some very
+# subtle Makefile assignment semantics.
+# https://www.gnu.org/software/make/manual/html_node/Setting.html
+VERSION_LDFLAGS:=-X $(PKG)/version.gitVersion=$(GIT_TAG) -X $(PKG)/version.gitCommit=$(GIT_COMMIT) -X $(PKG)/version.buildDate=$(BUILD_DATE)
 
 metrics-server: $(SRC_DEPS)
 	GOARCH=$(ARCH) CGO_ENABLED=0 go build -mod=readonly -ldflags "$(LDFLAGS)" -o metrics-server sigs.k8s.io/metrics-server/cmd/metrics-server

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ GOLANGCI_VERSION:=1.51.2
 # ------------------
 GOPATH:=$(shell go env GOPATH)
 REPO_DIR:=$(shell pwd)
-LDFLAGS=-w $(VERSION_LDFLAGS)
 
 .PHONY: all
 all: metrics-server
@@ -33,10 +32,8 @@ all: metrics-server
 SRC_DEPS=$(shell find pkg cmd -type f -name "*.go") go.mod go.sum
 CHECKSUM=$(shell md5sum $(SRC_DEPS) | md5sum | awk '{print $$1}')
 PKG:=k8s.io/client-go/pkg
-# This variable is included into LDFLAGS above based on some very
-# subtle Makefile assignment semantics.
-# https://www.gnu.org/software/make/manual/html_node/Setting.html
 VERSION_LDFLAGS:=-X $(PKG)/version.gitVersion=$(GIT_TAG) -X $(PKG)/version.gitCommit=$(GIT_COMMIT) -X $(PKG)/version.buildDate=$(BUILD_DATE)
+LDFLAGS:=-w $(VERSION_LDFLAGS)
 
 metrics-server: $(SRC_DEPS)
 	GOARCH=$(ARCH) CGO_ENABLED=0 go build -mod=readonly -ldflags "$(LDFLAGS)" -o metrics-server sigs.k8s.io/metrics-server/cmd/metrics-server


### PR DESCRIPTION

**What this PR does / why we need it**:

tl;dr With this change, we should properly get `-w` added the the `LDFLAGS`, which should shrink the `metrics-server` binary a bunch (clearly as originally intended!).


Today the `Makefile` has two lines that define `LDFLAGS` in different ways:
```Makefile
LDFLAGS=-w $(VERSION_LDFLAGS)
...
LDFLAGS:=-X $(PKG)/version.gitVersion=$(GIT_TAG) -X $(PKG)/version.gitCommit=$(GIT_COMMIT) -X $(PKG)/version.buildDate=$(BUILD_DATE)
```

What puzzled me is that the latter seems to overwrite the former (spoilers: it does), and I see no definition of `VERSION_LDFLAGS` anywhere.  Moreover, what's being put into `LDFLAGS` in the latter is what other repos are putting into `VERSION_LDFLAGS`!

The differing assignments `=` vs. `:=` puzzled me, and so I did some digging to understand this Makefile syntax a bit better finding these three useful links: https://www.gnu.org/software/make/manual/html_node/Setting.html https://www.gnu.org/software/make/manual/html_node/Flavors.html https://www.gnu.org/software/make/manual/html_node/Recursive-Assignment.html

I also crafted a trivial `Makefile` to confirm the before/after behavior was as I suspected:
```Makefile
LDFLAGS=-w $(VERSION_LDFLAGS)

SRC_DEPS=$(shell find pkg cmd -type f -name "*.go") go.mod go.sum
CHECKSUM=$(shell md5sum $(SRC_DEPS) | md5sum | awk '{print $$1}')
PKG:=k8s.io/client-go/pkg
VERSION_LDFLAGS:=-X $(PKG)/version.gitVersion=$(GIT_TAG) -X $(PKG)/version.gitCommit=$(GIT_COMMIT) -X $(PKG)/version.buildDate=$(BUILD_DATE)

all:
	echo $(LDFLAGS)
```