### PR TITLE
Update golangci-lint to v1.53.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - depguard
     - dogsled
     - dupl
     - errcheck

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 
 # Tools versions
 # --------------
-GOLANGCI_VERSION:=1.51.2
+GOLANGCI_VERSION:=1.53.2
 
 # Computed variables
 # ------------------


### PR DESCRIPTION
I disabled depguard since we don't really need an allowed list of dependencies and because metrics-server's repo didn't have one, the linter starting complaining after the update.
