### PR TITLE
feat(helm chart): Add metrics-server hardening options

### DIFF
--- a/.github/workflows/lint-test-chart.yaml
+++ b/.github/workflows/lint-test-chart.yaml
@@ -87,6 +87,38 @@ jobs:
         with:
           wait: 120s
 
+      - name: Install cert-manager dependency
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          helm repo add jetstack https://charts.jetstack.io
+          helm install cert-manager jetstack/cert-manager \
+            --namespace cert-manager \
+            --create-namespace \
+            --wait \
+            --set installCRDs=true \
+            --set extraArgs='{--enable-certificate-owner-ref}'
+
+      - name: Prepare existing secret test scenario
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          openssl req -x509 -newkey rsa:2048 -sha256 -days 365 \
+            -nodes -keyout ${{ runner.temp }}/tls.key -out ${{ runner.temp }}/tls.crt \
+            -subj "/CN=metrics-server" \
+            -addext "subjectAltName=DNS:metrics-server,DNS:metrics-server.kube-system.svc"
+
+          kubectl -n kube-system create secret generic metrics-server-existing \
+            --from-file=${{ runner.temp }}/tls.key \
+            --from-file=${{ runner.temp }}/tls.crt
+
+          cat <<EOF >> charts/metrics-server/ci/tls-existingSecret-values.yaml
+          apiService:
+            insecureSkipTLSVerify: false
+            caBundle: |
+          $(cat ${{ runner.temp }}/tls.crt  | sed -e "s/^/    /g")
+          EOF
+
+          rm ${{ runner.temp }}/tls.key ${{ runner.temp }}/tls.crt
+
       - name: Run chart-testing install
         if: steps.changes.outputs.changed == 'true'
-        run: ct install
+        run: ct install --namespace kube-system

--- a/charts/metrics-server/CHANGELOG.md
+++ b/charts/metrics-server/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ## [UNRELEASED]
 
+### Added
+
+- Add options on howto secure the connection between metrics-server and the kube-apiserver. ([#1288](https://github.com/kubernetes-sigs/metrics-server/pull/1288)) _@mkilchhofer_
+
 ## [3.12.2] - TBC
 
 ### Added

--- a/charts/metrics-server/ci/tls-certManager-values.yaml
+++ b/charts/metrics-server/ci/tls-certManager-values.yaml
@@ -1,0 +1,8 @@
+args:
+  - --kubelet-insecure-tls
+
+apiService:
+  insecureSkipTLSVerify: false
+
+tls:
+  type: cert-manager

--- a/charts/metrics-server/ci/tls-existingSecret-values.yaml
+++ b/charts/metrics-server/ci/tls-existingSecret-values.yaml
@@ -1,0 +1,12 @@
+args:
+  - --kubelet-insecure-tls
+
+## Set via GH action (step "Prepare existing secret test scenario")
+# apiService:
+#   insecureSkipTLSVerify: false
+#   caBundle: |
+
+tls:
+  type: existingSecret
+  existingSecret:
+    name: metrics-server-existing

--- a/charts/metrics-server/ci/tls-helm-values.yaml
+++ b/charts/metrics-server/ci/tls-helm-values.yaml
@@ -1,0 +1,8 @@
+args:
+  - --kubelet-insecure-tls
+
+apiService:
+  insecureSkipTLSVerify: false
+
+tls:
+  type: helm

--- a/charts/metrics-server/templates/apiservice.yaml
+++ b/charts/metrics-server/templates/apiservice.yaml
@@ -1,17 +1,63 @@
-{{- if .Values.apiService.create -}}
+{{- $altNames := list }}
+{{- $certs := dict }}
+{{- $previous := dict }}
+
+{{- if eq .Values.tls.type "helm" }}
+{{- $previous = lookup "v1" "Secret" .Release.Namespace (include "metrics-server.fullname" .) }}
+{{- $commonName := include "metrics-server.fullname" . }}
+{{- $ns := .Release.Namespace }}
+{{- $altNames = append $altNames (printf "%s.%s" $commonName $ns) }}
+{{- $altNames = append $altNames (printf "%s.%s.svc" $commonName $ns) }}
+{{- $altNames = append $altNames (printf "%s.%s.svc.%s" $commonName $ns .Values.tls.clusterDomain) }}
+{{- $certs = genSelfSignedCert $commonName nil $altNames (int .Values.tls.helm.certDurationDays) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "metrics-server.fullname" . }}
+  labels:
+    {{- include "metrics-server.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if and $previous .Values.tls.helm.lookup }}
+  tls.crt: {{ index $previous.data "tls.crt" }}
+  tls.key: {{ index $previous.data "tls.key" }}
+  {{- else }}
+  tls.crt: {{ $certs.Cert| b64enc | quote }}
+  tls.key: {{ $certs.Key | b64enc | quote }}
+  {{- end }}
+{{- end }}
+---
+{{- $existing := dict }}
+{{- if .Values.apiService.create }}
+{{- if and (eq .Values.tls.type "existingSecret") .Values.tls.existingSecret.lookup }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace .Values.tls.existingSecret.name }}
+{{- end }}
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1beta1.metrics.k8s.io
   labels:
     {{- include "metrics-server.labels" . | nindent 4 }}
-  {{- with .Values.apiService.annotations }}
+  {{- if or .Values.apiService.annotations .Values.tls.certManager.addInjectorAnnotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- if and (eq .Values.tls.type "cert-manager") .Values.tls.certManager.addInjectorAnnotations }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "metrics-server.fullname" . }}
+    {{- end }}
+    {{- with .Values.apiService.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
-  {{- with .Values.apiService.caBundle }}
-  caBundle: {{ b64enc . }}
+  {{- if eq .Values.tls.type "helm" }}
+    {{- if and $previous .Values.tls.helm.lookup }}
+  caBundle: {{ index $previous.data "tls.crt" }}
+    {{- else }}
+  caBundle: {{ $certs.Cert | b64enc }}
+    {{- end }}
+  {{- else if $existing }}
+  caBundle: {{ index $existing.data "tls.crt" }}
+  {{- else if and .Values.apiService.caBundle (ne .Values.tls.type "cert-manager") }}
+  caBundle: {{ .Values.apiService.caBundle | b64enc }}
   {{- end }}
   group: metrics.k8s.io
   groupPriorityMinimum: 100
@@ -22,4 +68,4 @@ spec:
     port: {{ .Values.service.port }}
   version: v1beta1
   versionPriority: 100
-{{- end -}}
+{{- end }}

--- a/charts/metrics-server/templates/certificate.yaml
+++ b/charts/metrics-server/templates/certificate.yaml
@@ -1,0 +1,47 @@
+{{- if eq .Values.tls.type "cert-manager" }}
+{{- if not .Values.tls.certManager.existingIssuer.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  annotations:
+    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+  name: {{ include "metrics-server.fullname" . }}-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+{{- end }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "metrics-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  commonName: {{ include "metrics-server.fullname" . }}
+  dnsNames:
+  - {{ include "metrics-server.fullname" . }}.{{ .Release.Namespace }}
+  - {{ include "metrics-server.fullname" . }}.{{ .Release.Namespace }}.svc
+  - {{ include "metrics-server.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.tls.clusterDomain }}
+  secretName: {{ include "metrics-server.fullname" . }}
+  usages:
+    - server auth
+    - client auth
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  {{- with .Values.tls.certManager.duration }}
+  duration: {{ . }}
+  {{- end }}
+  {{- with .Values.tls.certManager.renewBefore }}
+  renewBefore: {{ . }}
+  {{- end }}
+  issuerRef:
+    {{- if .Values.tls.certManager.existingIssuer.enabled }}
+    name: {{ .Values.tls.certManager.existingIssuer.name }}
+    kind: {{ .Values.tls.certManager.existingIssuer.kind }}
+    {{- else }}
+    name: {{ include "metrics-server.fullname" . }}-issuer
+    kind: Issuer
+    {{- end }}
+    group: cert-manager.io
+{{- end }}

--- a/charts/metrics-server/templates/deployment.yaml
+++ b/charts/metrics-server/templates/deployment.yaml
@@ -71,6 +71,10 @@ spec:
           {{- if .Values.metrics.enabled }}
             - --authorization-always-allow-paths=/metrics
           {{- end }}
+          {{- if ne .Values.tls.type "metrics-server" }}
+            - --tls-cert-file=/tmp/tls-certs/tls.crt
+            - --tls-private-key-file=/tmp/tls-certs/tls.key
+          {{- end }}
           {{- range .Values.args }}
             - {{ . }}
           {{- end }}
@@ -89,6 +93,11 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+              {{- if ne .Values.tls.type "metrics-server" }}
+            - mountPath: /tmp/tls-certs
+              name: certs
+              readOnly: true
+              {{- end }}
           {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -137,6 +146,15 @@ spec:
         - name: nanny-config-volume
           configMap:
             name: {{ include "metrics-server.addonResizer.configMap" . }}
+      {{- end }}
+      {{- if ne .Values.tls.type "metrics-server" }}
+        - name: certs
+          secret:
+            {{- if and (eq .Values.tls.type "existingSecret") .Values.tls.existingSecret.name }}
+            secretName: {{ .Values.tls.existingSecret.name }}
+            {{- else }}
+            secretName: {{ include "metrics-server.fullname" . }}
+            {{- end }}
       {{- end }}
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/metrics-server/values.yaml
+++ b/charts/metrics-server/values.yaml
@@ -198,3 +198,47 @@ schedulerName: ""
 
 tmpVolume:
   emptyDir: {}
+
+tls:
+  # Set the TLS method to use. Supported values:
+  # - `metrics-server` : Metrics-server will generate a self-signed certificate
+  # - `helm`           : Helm will generate a self-signed certificate
+  # - `cert-manager`   : Use cert-manager.io to create and maintain the certificate
+  # - `existingSecret` : Reuse an existing secret. No new secret will be created
+  type: "metrics-server"
+  # Kubernetes cluster domain. Used to configure Subject Alt Names for the certificate
+  clusterDomain: cluster.local
+
+  certManager:
+    # Automatically add the cert-manager.io/inject-ca-from annotation to the APIService resource.
+    # See https://cert-manager.io/docs/concepts/ca-injector
+    addInjectorAnnotations: true
+    existingIssuer:
+      # Use an existing cert-manager issuer
+      enabled: false
+      # Kind of the existing cert-manager issuer
+      kind: "Issuer"
+      # Name of the existing cert-manager issuer
+      name: "my-issuer"
+    # Set the requested duration (i.e. lifetime) of the Certificate.
+    # See https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec
+    duration: ""
+    # How long before the currently issued certificate’s expiry cert-manager should renew the certificate.
+    # See https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec
+    renewBefore: ""
+    # Add extra annotations to the Certificate resource
+    annotations: {}
+    # Add extra labels to the Certificate resource
+    labels: {}
+
+  helm:
+    # Use helm lookup function to reuse Secret created in previous helm install
+    lookup: true
+    # Cert validity duration in days
+    certDurationDays: 365
+
+  existingSecret:
+    # Name of the existing Secret to use for TLS
+    name: ""
+    # Use helm lookup function to provision `apiService.caBundle`
+    lookup: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

It adds options on howto secure the connection between metrics-server and the kube-apiserver.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

related to:
- #545

**Additional info**:
n/a

/cc: @serathius

