### PR TITLE
kernel bug lead to incorrect cpu usage

### DIFF
--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -51,6 +51,9 @@ type MetricsPoint struct {
 }
 
 func resourceUsage(last, prev MetricsPoint) (corev1.ResourceList, api.TimeInfo, error) {
+	if last.StartTime.Before(prev.StartTime) {
+		return corev1.ResourceList{}, api.TimeInfo{}, fmt.Errorf("unexpected decrease in startTime of node/container")
+	}
 	if last.CumulativeCpuUsed < prev.CumulativeCpuUsed {
 		return corev1.ResourceList{}, api.TimeInfo{}, fmt.Errorf("unexpected decrease in cumulative CPU usage value")
 	}


### PR DESCRIPTION
in one case，metrics-server will respons incorrect cpu usage，detailed description is as follows：
A StatefulSet pod named pod-0 used to run on a node named node1, this pod is then scheduled to run on node2，node1 has a kernel bug that causes the resource usage information of the pod-0 is stored，so when metrics-server pulls datas，which can pull pod-0 datas on node1 and node2, and drop node2's data， then when hpa controller gets pod-0 cpu usage will get a very large value，eg：pod-0 ran in node1 3 days ago,which used cpu accumulate 518400，and then pod-0 now running in node2 and used cpu accumulate 30， in this case, the calculated cpu usage is very large，the calcute way is described as follows:
1. subValue: 518400 - 30
2. windows: time.Now().Add(-3*24*time.Hour).Sub(time.Now())
3. cpuUsage: subValue / windows = (518400 - 30) / time.Now().Add(-3*24*time.Hour).Sub(time.Now()).Seconds()
4. res = uint64Qunatity(uint64(cpuUsage), resource.DecimalSI, -9)
5. res is 18446744074
so when calcute cpu usage，needing add a judge about data's collected timestamp