### PR TITLE
Update autoscaling configuration to follow README recommendation

### DIFF
--- a/manifests/components/autoscale/patch.yaml
+++ b/manifests/components/autoscale/patch.yaml
@@ -32,14 +32,14 @@ spec:
                   fieldPath: metadata.namespace
           command:
             - /pod_nanny
-            - --cpu=20m
+            - --cpu=0m
             - --extra-cpu=1m
-            - --memory=15Mi
+            - --memory=0Mi
             - --extra-memory=2Mi
             - --threshold=5
             - --deployment=metrics-server
             - --container=metrics-server
             - --poll-period=300000
             - --estimator=exponential
-            - --minClusterSize=10
+            - --minClusterSize=100
             - --use-metrics=true


### PR DESCRIPTION
/assign @dgrisonnet @yangjunmyfm192085 

Set 100m Cores and 200MiB for clusters with less than 100 nodes. Add 1m core and 2MiB per each additional node.

Equation on addon-resizer is `base + extra * max(numberOfNodes, minClusterSize)`.
So for so with `minClusterSize=100` we get:
* CPU: 0+1 * max(numberOfNodes, 100)`
* Memory: 0+2 * max(numberOfNodes, 100)`