### PR TITLE
Updated addon-resizer patch version

### DIFF
--- a/manifests/components/autoscale/patch.yaml
+++ b/manifests/components/autoscale/patch.yaml
@@ -13,7 +13,7 @@ spec:
           resources:
             $patch: delete
         - name: metrics-server-nanny
-          image: registry.k8s.io/autoscaling/addon-resizer:1.8.14
+          image: registry.k8s.io/autoscaling/addon-resizer:1.8.19
           resources:
             limits:
               cpu: 40m


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR updates the addon-resizer image used for autoscaling to the latest patch version on the `v1.8` line which is a multi-platform image and so can be used on ARM64 nodes.

