### PR TITLE
feat(chart): Match version label with image tag

### DIFF
--- a/charts/metrics-server/templates/_helpers.tpl
+++ b/charts/metrics-server/templates/_helpers.tpl
@@ -37,7 +37,7 @@ Common labels
 helm.sh/chart: {{ include "metrics-server.chart" . }}
 {{ include "metrics-server.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ (default .Chart.AppVersion (trimPrefix "v" .Values.image.tag)) | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.commonLabels }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Avoid mismatched version values in `Values.image.tag` and `app.kubernetes.io/version`.

Previously, `app.kubernetes.io/version` referenced .Chart.AppVersion even if `Values.image.tag` was specified.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

