### PR TITLE
Create Dependabot Configuation to support Docker and go module updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,26 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: weekly
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: weekly
+  groups:
+    gomod-dependencies:
+      patterns:
+        - "*"
+- package-ecosystem: gomod
+  directory: /scripts
+  schedule:
+    interval: weekly
+  groups:
+    gomod-dependencies:
+      patterns:
+        - "*"


### PR DESCRIPTION

Enable Dependabot for Dockerfile and go.mod updates.
This will update images in Dockerfile `FROM` statements, and go modules.

This PR is created by a script. Please let me know if we should modify any values.
