### PR TITLE
update e2e tools and bump golang to 1.20.11 in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Update the base image in Makefile when updating golang version. This has to
 # be pre-pulled in order to work on GCB.
 ARG ARCH
-FROM golang:1.20.5 as build
+FROM golang:1.20.11 as build
 
 WORKDIR /go/src/sigs.k8s.io/metrics-server
 COPY go.mod .

--- a/test/test-e2e.sh
+++ b/test/test-e2e.sh
@@ -7,9 +7,9 @@ set -e
 
 
 KIND_VERSION=0.20.0
-SKAFFOLD_VERSION=2.7.0
-HELM_VERSION=3.10.2
-KUBECTL_VERSION=1.28.1
+SKAFFOLD_VERSION=2.9.0
+HELM_VERSION=3.13.2
+KUBECTL_VERSION=1.28.4
 
 delete_cluster() {
   ${KIND} delete cluster --name=e2e &> /dev/null || true


### PR DESCRIPTION
**What this PR does / why we need it**:
- update e2e tools and bump golang to 1.20.11 in dockerfile

/assign @serathius @s-urbaniak @dgrisonnet


tested locally

```
.....
Ran 10 of 10 Specs in 46.615 seconds
SUCCESS! -- 10 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestMetricsServer (46.62s)
PASS
ok      command-line-arguments  46.925s
````


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

