### PR TITLE
Add a tip about using kubelet-insecure-tls argument

### DIFF
--- a/charts/metrics-server/README.md
+++ b/charts/metrics-server/README.md
@@ -87,3 +87,11 @@ The following table lists the configurable parameters of the _Metrics Server_ ch
 | `deploymentAnnotations`              | Annotations to add to the deployment.                                                                                                                                                                                                                            | `{}`                                                                           |
 | `schedulerName`                      | scheduler to set to the deployment.                                                                                                                                                                                                                              | `""`                                                                           |
 | `dnsConfig`                          | Set the dns configuration options for the deployment.                                                                                                                                                                                                            | `{}`                                                                           |
+
+# Tips
+
+- By default, many Kubernetes clusters have no signed by cluster Certificate Authority Kubelet certificates, which leads to the "xxx" error. To resolve this, you should either configure signed certificates or allow insecure connections by adding an argument to the `values.yaml` file:
+```yaml
+args:
+  - --kubelet-insecure-tls
+```

--- a/charts/metrics-server/README.md
+++ b/charts/metrics-server/README.md
@@ -90,8 +90,7 @@ The following table lists the configurable parameters of the _Metrics Server_ ch
 
 # Tips
 
-- By default, many Kubernetes clusters have no signed by cluster Certificate Authority Kubelet certificates, which leads to the "x509: cannot validate certificate for x.x.x.x because it doesn't contain any IP SANs
-" error. To resolve this, you should either configure signed certificates or allow insecure connections by adding an argument to the `values.yaml` file:
+- By default, many Kubernetes clusters have no signed by cluster Certificate Authority Kubelet certificates, which leads to the "x509: cannot validate certificate for x.x.x.x because it doesn't contain any IP SANs" error. To resolve this, you should either configure signed certificates or allow insecure connections by adding an argument to the `values.yaml` file:
 ```yaml
 args:
   - --kubelet-insecure-tls

--- a/charts/metrics-server/README.md
+++ b/charts/metrics-server/README.md
@@ -90,7 +90,8 @@ The following table lists the configurable parameters of the _Metrics Server_ ch
 
 # Tips
 
-- By default, many Kubernetes clusters have no signed by cluster Certificate Authority Kubelet certificates, which leads to the "xxx" error. To resolve this, you should either configure signed certificates or allow insecure connections by adding an argument to the `values.yaml` file:
+- By default, many Kubernetes clusters have no signed by cluster Certificate Authority Kubelet certificates, which leads to the "x509: cannot validate certificate for x.x.x.x because it doesn't contain any IP SANs
+" error. To resolve this, you should either configure signed certificates or allow insecure connections by adding an argument to the `values.yaml` file:
 ```yaml
 args:
   - --kubelet-insecure-tls


### PR DESCRIPTION
**What this PR does / why we need it**:
The most common problem when installing the metrics-server helm chart with the default Kubernetes configuration is getting the error like this:
```
Failed to scrape node" err="Get \"https://10.0.0.2:10250/metrics/resource\": x509: cannot validate certificate for 10.0.0.2 because it doesn't contain any IP SANs
```
And there is no clear solution described in the current docs.

My PR adds a tip on how to resolve this problem.

**Which issue(s) this PR fixes**:
Fixes #1221

