### PR TITLE
[release-0.5] cherrypick #1300 kernel bug lead to incorrect cpu usage

### DIFF
--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -65,6 +65,9 @@ type MetricsPoint struct {
 }
 
 func resourceUsage(last, prev MetricsPoint) (corev1.ResourceList, api.TimeInfo, error) {
+	if last.StartTime.Before(prev.StartTime) {
+		return corev1.ResourceList{}, api.TimeInfo{}, fmt.Errorf("unexpected decrease in startTime of node/container")
+	}
 	if last.CumulativeCpuUsed < prev.CumulativeCpuUsed {
 		return corev1.ResourceList{}, api.TimeInfo{}, fmt.Errorf("unexpected decrease in cumulative CPU usage value")
 	}

--- a/pkg/storage/types_test.go
+++ b/pkg/storage/types_test.go
@@ -16,9 +16,13 @@ package storage
 
 import (
 	"math"
+	"reflect"
 	"testing"
+	"time"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/metrics-server/pkg/api"
 )
 
 func TestUint64Quantity(t *testing.T) {
@@ -37,6 +41,58 @@ func TestUint64Quantity(t *testing.T) {
 			got := uint64Quantity(tc.input, resource.DecimalSI, 0)
 			if got != tc.expect {
 				t.Errorf("uint64Quantity(%d, resource.DecimalSI, 0) = %+v, expected: %+v", tc.input, got, tc.expect)
+			}
+		})
+	}
+}
+
+func Test_resourceUsage(t *testing.T) {
+	start := time.Now()
+	tcs := []struct {
+		name             string
+		last             MetricsPoint
+		prev             MetricsPoint
+		wantResourceList v1.ResourceList
+		wantTimeInfo     api.TimeInfo
+		wantErr          bool
+	}{
+		{
+			name: "get resource usage successfully",
+			last: newMetricsPoint(start, start.Add(20*time.Millisecond), 500, 600),
+			prev: newMetricsPoint(start, start.Add(10*time.Millisecond), 300, 400),
+			wantResourceList: v1.ResourceList{v1.ResourceCPU: uint64Quantity(uint64(20000), resource.DecimalSI, -9),
+				v1.ResourceMemory: uint64Quantity(600, resource.BinarySI, 0)},
+			wantTimeInfo: api.TimeInfo{Timestamp: start.Add(20 * time.Millisecond), Window: 10 * time.Millisecond},
+		},
+		{
+			name:             "get resource usage failed because of unexpected decrease in startTime",
+			last:             newMetricsPoint(start, start.Add(20*time.Millisecond), 500, 600),
+			prev:             newMetricsPoint(start.Add(20*time.Millisecond), start.Add(10*time.Millisecond), 300, 400),
+			wantResourceList: v1.ResourceList{},
+			wantTimeInfo:     api.TimeInfo{},
+			wantErr:          true,
+		},
+		{
+			name:             "get resource usage failed because of unexpected decrease in cumulative CPU usage value",
+			last:             newMetricsPoint(start, start.Add(20*time.Millisecond), 100, 600),
+			prev:             newMetricsPoint(start, start.Add(10*time.Millisecond), 300, 400),
+			wantResourceList: v1.ResourceList{},
+			wantTimeInfo:     api.TimeInfo{},
+			wantErr:          true,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			resourceList, timeInfo, err := resourceUsage(tc.last, tc.prev)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("resourceUsage() error = %v, wantErr %v", err, tc.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(resourceList, tc.wantResourceList) {
+				t.Errorf("resourceUsage() resourceList = %v, want %v", resourceList, tc.wantResourceList)
+			}
+			if !reflect.DeepEqual(timeInfo, tc.wantTimeInfo) {
+				t.Errorf("resourceUsage() timeInfo = %v, want %v", timeInfo, tc.wantTimeInfo)
 			}
 		})
 	}


### PR DESCRIPTION
What this PR does / why we need it:
cherrypick https://github.com/kubernetes-sigs/metrics-server/pull/1300
Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

