### PR TITLE
fix(chart): Fixed incorrect changelog version lookup

### DIFF
--- a/.github/workflows/lint-test-chart.yaml
+++ b/.github/workflows/lint-test-chart.yaml
@@ -57,7 +57,7 @@ jobs:
         uses: mindsers/changelog-reader-action@b97ce03a10d9bdbb07beb491c76a5a01d78cd3ef # v2.2.2
         with:
           path: charts/metrics-server/CHANGELOG.md
-          version: ${{ steps.chart_version.outputs.version }}
+          version: ${{ steps.chart_version.outputs.result }}
 
       - name: Set-up Artifact Hub CLI
         if: steps.changes.outputs.changed == 'true'

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -71,7 +71,7 @@ jobs:
         uses: mindsers/changelog-reader-action@b97ce03a10d9bdbb07beb491c76a5a01d78cd3ef # v2.2.2
         with:
           path: charts/metrics-server/CHANGELOG.md
-          version: ${{ steps.chart_version.outputs.version }}
+          version: ${{ steps.chart_version.outputs.result }}
 
       - name: Create release notes
         if: steps.check_can_release.outputs.continue == 'true'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR fixes the CHANGELOG lookup logic in the Helm chart automation. Due to the incorrect configuration it doesn't find the correct entry or error if the entry doesn't exist due to there being no version passed in.

**Which issue(s) this PR fixes**:
n/a

