### PR TITLE
release-0.7: Fix kubectl get PodMetrics/NodeMetrics 

### DIFF
--- a/pkg/api/node.go
+++ b/pkg/api/node.go
@@ -178,5 +178,5 @@ func (m *nodeMetrics) NamespaceScoped() bool {
 
 // GetSingularName implements rest.SingularNameProvider interface
 func (m *nodeMetrics) GetSingularName() string {
-	return "node"
+	return ""
 }

--- a/pkg/api/pod.go
+++ b/pkg/api/pod.go
@@ -185,5 +185,5 @@ func (m *podMetrics) NamespaceScoped() bool {
 
 // GetSingularName implements rest.SingularNameProvider interface
 func (m *podMetrics) GetSingularName() string {
-	return "pod"
+	return ""
 }


### PR DESCRIPTION
Backport of https://github.com/kubernetes-sigs/metrics-server/pull/1436 to release-0.7
