### PR TITLE
fix: service monitor to include service account token (of prom pods) as the bearer token when scraping

### DIFF
--- a/charts/metrics-server/templates/servicemonitor.yaml
+++ b/charts/metrics-server/templates/servicemonitor.yaml
@@ -21,7 +21,9 @@ spec:
     - port: https
       path: /metrics
       scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         insecureSkipVerify: true
       {{- with .Values.serviceMonitor.interval }}
       interval: {{ . }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
re-configures the servicemonitor manifest under the helm chart to use serviceAccountToken (of the Prom pods) as the bearer token when scraping the metrics-server.

This is because metrics-server is gated by such an authz that it could be only passed by the privileges of the serviceAccount token of the Prom pods.

Else, 403 forbidden would be returned (which has been happening as of now whenever the current service monitor is applied.)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1449 

**Screenshot before this pull request**

<img width="1727" alt="image" src="https://github.com/kubernetes-sigs/metrics-server/assets/25801460/0861a158-f080-4ca9-afe6-9ece1dc0655c">

Original Service Monitor causing this issue:

```yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: metrics-server-sm
  namespace: kube-system
  labels:
    release: kube-prometheus-stack-1711317473
spec:
  namespaceSelector:
    matchNames:
      - kube-system
  selector:
    matchLabels:
      k8s-app: metrics-server
  endpoints:
    - port: https
      scheme: https
      path: /metrics
      tlsConfig:
        insecureSkipVerify: true
```

**Screenshot after this pull request**

<img width="1728" alt="image" src="https://github.com/kubernetes-sigs/metrics-server/assets/25801460/761ea469-93a2-4a8d-8a9a-04908f9f5918">

New Service Monitor, based on this PR, which resolved the issue:

```yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: metrics-server-sm
  namespace: kube-system
  labels:
    release: kube-prometheus-stack-1711317473
spec:
  namespaceSelector:
    matchNames:
      - kube-system
  selector:
    matchLabels:
      k8s-app: metrics-server
  endpoints:
    - port: https
      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
      scheme: https
      path: /metrics
      tlsConfig:
        caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
        insecureSkipVerify: true
```
