### PR TITLE
chore(chart): add conditional include on optional Deployment schedule…

### DIFF
--- a/charts/metrics-server/CHANGELOG.md
+++ b/charts/metrics-server/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Changed
 
 - Updated the _Metrics Server_ OCI image to [v0.7.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.1). ([#1461](https://github.com/kubernetes-sigs/metrics-server/pull/1461)) _@stevehipwell_
+- Changed `Deployment` templating to ignore `schedulerName` when value is empty. ([#1475](https://github.com/kubernetes-sigs/metrics-server/pull/1475)) _@senges_
 
 ## [3.12.0] - 2024-02-07
 

--- a/charts/metrics-server/templates/deployment.yaml
+++ b/charts/metrics-server/templates/deployment.yaml
@@ -33,7 +33,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      schedulerName: {{ .Values.schedulerName }}
+      {{- with .Values.schedulerName }}
+      schedulerName: {{ . }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
**What this PR does / why we need it**:

`spec.template.spec.schedulerName` is an optional `Deployment` field. By default, it is set to empty string in Values.yaml file which is then treated as nil value from helm.

Consequence is that `helm template` will generate an invalid YAML with an empty value:

```
---
# Source: metrics-server/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
[...]
spec:
  template:
    spec:
      schedulerName: 
      serviceAccountName: release-name-metrics-server
      priorityClassName: "system-cluster-critical"
[...]
```

