### PR TITLE
fix(helm): nanny rolebinding needs to be in release ns

### DIFF
--- a/charts/metrics-server/CHANGELOG.md
+++ b/charts/metrics-server/CHANGELOG.md
@@ -14,6 +14,11 @@
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Fixed nanny's RoleBinding which contained a hard-coded namespace instead of the Helm's release namespace. ([#1479](https://github.com/kubernetes-sigs/metrics-server/pull/1479)) _@
+the-technat_
+
 ## [3.12.1] - TBC
 
 ### Changed

--- a/charts/metrics-server/templates/rolebinding-nanny.yaml
+++ b/charts/metrics-server/templates/rolebinding-nanny.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ printf "%s-nanny" (include "metrics-server.fullname" .)  }}
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "metrics-server.labels" . | nindent 4 }}
 roleRef:


### PR DESCRIPTION
Just discovered in our k8s environment that nanny isn't working as expected. Instead of working around this issue by hacking in a custom rolebinding, I thought I'll fix this upstream. The change itself should be really simple and seems to be a leftover of PR #1234.

**What this PR does / why we need it**: Allows nanny to patch it's deployment and adjust resource limits according to current usage.

**Which issue(s) this PR fixes**: Fixes #1275 

