### PR TITLE
feat: add helm capability check on servicemonitor

### DIFF
--- a/charts/metrics-server/templates/servicemonitor.yaml
+++ b/charts/metrics-server/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceMonitor.enabled .Values.metrics.enabled -}}
+{{- if and .Values.serviceMonitor.enabled .Values.metrics.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Details in issue, but this provides extra safety on helm installs enabling the servicemonitor to validate that the CRD is present.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/metrics-server/issues/1481

