### PR TITLE
Add new flag to allow CA as text argument for kubelet client

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -72,7 +72,7 @@ Suggested configuration:
 
 - Cluster with [RBAC] enabled
 - Kubelet [read-only port] port disabled
-- Validate kubelet certificate by mounting CA file and providing `--kubelet-certificate-authority` flag to metrics server
+- Validate kubelet certificate by mounting CA file and providing `--kubelet-certificate-authority` flag or passing CA text using `--kubelet-certificate-authority-text` flag to metrics server
 - Avoid passing insecure flags to metrics server (`--deprecated-kubelet-completely-insecure`, `--kubelet-insecure-tls`)
 - Consider using your own certificates (`--tls-cert-file`, `--tls-private-key-file`)
 

--- a/cmd/metrics-server/app/options/kubelet_client_test.go
+++ b/cmd/metrics-server/app/options/kubelet_client_test.go
@@ -162,6 +162,24 @@ func TestValidate(t *testing.T) {
 			expectedErrorCount: 0,
 		},
 		{
+			name: "Cannot use both --kubelet-certificate-authority-text and --kubelet-certificate-authority",
+			options: &KubeletClientOptions{
+				KubeletCAFile:         "a",
+				KubeletCAText:         "a",
+				KubeletRequestTimeout: 1 * time.Second,
+			},
+			expectedErrorCount: 1,
+		},
+		{
+			name: "Cannot use both --kubelet-certificate-authority-text and --deprecated-kubelet-completely-insecure",
+			options: &KubeletClientOptions{
+				DeprecatedCompletelyInsecureKubelet: true,
+				KubeletCAText:                       "a",
+				KubeletRequestTimeout:               1 * time.Second,
+			},
+			expectedErrorCount: 1,
+		},
+		{
 			name: "Cannot use both --kubelet-certificate-authority and --deprecated-kubelet-completely-insecure",
 			options: &KubeletClientOptions{
 				DeprecatedCompletelyInsecureKubelet: true,
@@ -175,6 +193,15 @@ func TestValidate(t *testing.T) {
 			options: &KubeletClientOptions{
 				InsecureKubeletTLS:    true,
 				KubeletCAFile:         "a",
+				KubeletRequestTimeout: 1 * time.Second,
+			},
+			expectedErrorCount: 1,
+		},
+		{
+			name: "Cannot use both --kubelet-certificate-authority-text and --kubelet-insecure-tls",
+			options: &KubeletClientOptions{
+				InsecureKubeletTLS:    true,
+				KubeletCAText:         "a",
 				KubeletRequestTimeout: 1 * time.Second,
 			},
 			expectedErrorCount: 1,
@@ -224,7 +251,7 @@ func TestValidate(t *testing.T) {
 			expectedErrorCount: 1,
 		},
 		{
-			name: "cannot give only --kubelet-client-key, give --kubelet-certificate-authority as well",
+			name: "cannot give only --kubelet-client-key, give --kubelet-client-certificate as well",
 			options: &KubeletClientOptions{
 				KubeletClientKeyFile:  "a",
 				KubeletRequestTimeout: 1 * time.Second,

--- a/docs/command-line-flags.txt
+++ b/docs/command-line-flags.txt
@@ -11,16 +11,17 @@ Metrics server flags:
 
 Kubelet client flags:
 
-      --deprecated-kubelet-completely-insecure    DEPRECATED: Do not use any encryption, authorization, or authentication when communicating with the Kubelet. This is rarely the right option, since it leaves kubelet communication completely insecure.  If you encounter auth errors, make sure you've enabled token webhook auth on the Kubelet, and if you're in a test cluster with self-signed Kubelet certificates, consider using kubelet-insecure-tls instead.
-      --kubelet-certificate-authority string      Path to the CA to use to validate the Kubelet's serving certificates.
-      --kubelet-client-certificate string         Path to a client cert file for TLS.
-      --kubelet-client-key string                 Path to a client key file for TLS.
-      --kubelet-insecure-tls                      Do not verify CA of serving certificates presented by Kubelets.  For testing purposes only.
-      --kubelet-port int                          The port to use to connect to Kubelets. (default 10250)
-      --kubelet-preferred-address-types strings   The priority of node address types to use when determining which address to use to connect to a particular node (default [Hostname,InternalDNS,InternalIP,ExternalDNS,ExternalIP])
-      --kubelet-request-timeout duration          The length of time to wait before giving up on a single request to Kubelet. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). (default 10s)
-      --kubelet-use-node-status-port              Use the port in the node status. Takes precedence over --kubelet-port flag.
-  -l, --node-selector string                      Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2).
+      --deprecated-kubelet-completely-insecure        DEPRECATED: Do not use any encryption, authorization, or authentication when communicating with the Kubelet. This is rarely the right option, since it leaves kubelet communication completely insecure.  If you encounter auth errors, make sure you've enabled token webhook auth on the Kubelet, and if you're in a test cluster with self-signed Kubelet certificates, consider using kubelet-insecure-tls instead.
+      --kubelet-certificate-authority string          Path to the CA to use to validate the Kubelet's serving certificates.
+      --kubelet-certificate-authority-text string     CA text to use to validate the Kubelet's serving certificates.
+      --kubelet-client-certificate string             Path to a client cert file for TLS.
+      --kubelet-client-key string                     Path to a client key file for TLS.
+      --kubelet-insecure-tls                          Do not verify CA of serving certificates presented by Kubelets.  For testing purposes only.
+      --kubelet-port int                              The port to use to connect to Kubelets. (default 10250)
+      --kubelet-preferred-address-types strings       The priority of node address types to use when determining which address to use to connect to a particular node (default [Hostname,InternalDNS,InternalIP,ExternalDNS,ExternalIP])
+      --kubelet-request-timeout duration              The length of time to wait before giving up on a single request to Kubelet. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). (default 10s)
+      --kubelet-use-node-status-port                  Use the port in the node status. Takes precedence over --kubelet-port flag.
+  -l, --node-selector string                          Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2).
 
 Apiserver secure serving flags:
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
- This PR adds support for new flag `--kubelet-certificate-authority-text` to allow passing CA as text for kubelet client. Added corresponding unit tests and updated docs.
- Also corrected the flag name in an [existing test case ](https://github.com/kubernetes-sigs/metrics-server/blob/v0.7.1/cmd/metrics-server/app/options/kubelet_client_test.go#L227)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1256

