### PR TITLE
explicit protocol selection with appProtocol

### DIFF
--- a/charts/metrics-server/templates/service.yaml
+++ b/charts/metrics-server/templates/service.yaml
@@ -19,5 +19,6 @@ spec:
       port: {{ .Values.service.port }}
       protocol: TCP
       targetPort: https
+      appProtocol: https
   selector:
     {{- include "metrics-server.selectorLabels" . | nindent 4 }}

--- a/manifests/base/service.yaml
+++ b/manifests/base/service.yaml
@@ -10,3 +10,4 @@ spec:
     port: 443
     protocol: TCP
     targetPort: https
+    appProtocol: https


### PR DESCRIPTION
**What this PR does / why we need it:**

For reasons not entirely clear to me, our istio installation doesn't recognize the protocol as https based on the port naming, resulting in the istio proxy inappropriately terminating the api-server->metrics-server TLS connection. Our testing shows that istio will use the appProtocol: https setting if provided, it should have no negative impact on other environments

