### PR TITLE
Add content write permissions to release jobs

### DIFF
--- a/.github/workflows/gh-workflow-approve.yaml
+++ b/.github/workflows/gh-workflow-approve.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   approve:
     name: Approve ok-to-test

--- a/.github/workflows/lint-test-chart.yaml
+++ b/.github/workflows/lint-test-chart.yaml
@@ -6,6 +6,9 @@ on:
       - .github/workflows/lint-test-chart.yaml
       - "charts/metrics-server/**"
 
+permissions:
+  contents: read
+
 jobs:
   lint-test:
     name: Lint & Test

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -7,6 +7,9 @@ on:
     paths:
       - charts/metrics-server/Chart.yaml
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Release
@@ -15,6 +18,8 @@ jobs:
     defaults:
       run:
         shell: bash
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,9 @@ on:
     types:
       - published
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: build
@@ -12,6 +15,8 @@ jobs:
     defaults:
       run:
         shell: bash
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7


### PR DESCRIPTION
This should work around the org-wide restriction on github actions write permission to the repos and fix the issue I encountered when releasing v0.7.2 where the jobs to publish the assets failed: https://github.com/kubernetes-sigs/metrics-server/actions/runs/10593979544