### PR TITLE
release-0.7: update golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ALL_BINARIES_PLATFORMS= $(addprefix linux/,$(ALL_ARCHITECTURES)) \
 
 # Tools versions
 # --------------
-GOLANGCI_VERSION:=1.55.2
+GOLANGCI_VERSION:=1.61.0
 
 # Computed variables
 # ------------------


### PR DESCRIPTION
This should address the CI failures from https://github.com/kubernetes-sigs/metrics-server/pull/1578.