### PR TITLE
include common labels in pod labels

### DIFF
--- a/charts/metrics-server/templates/deployment.yaml
+++ b/charts/metrics-server/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "metrics-server.selectorLabels" . | nindent 8 }}
+        {{- include "metrics-server.labels" . | nindent 8 }}
       {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
What this PR does / why we need it:

- it adds all common labels to metadata labels in the pod spec. The main reasoning is to persist the helm.sh/chart, app.kubernetes.io/version and app.kubernetes.io/name labels to the pod for standardization.  Per docs, (https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels) "In order to take full advantage of using these labels, they should be applied on every resource object.". 
- to improve traceability throughout the application. Ex. via Kiali dashboard. 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

