### PR TITLE
Add new metrics-server.podLabels with default version label and set on pods

### DIFF
--- a/charts/metrics-server/templates/_helpers.tpl
+++ b/charts/metrics-server/templates/_helpers.tpl
@@ -54,6 +54,16 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Pod labels
+*/}}
+{{- define "metrics-server.podLabels" -}}
+{{ include "metrics-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "metrics-server.serviceAccountName" -}}

--- a/charts/metrics-server/templates/deployment.yaml
+++ b/charts/metrics-server/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "metrics-server.selectorLabels" . | nindent 8 }}
+        {{- include "metrics-server.podLabels" . | nindent 8 }}
       {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
What this PR does / why we need it:

- It adds common labels to metadata labels in the pod spec. The main reasoning is to persist the app.kubernetes.io/version and app.kubernetes.io/name labels to the pod for standardization. Per docs, (https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels) "In order to take full advantage of using these labels, they should be applied on every resource object.".

- Improves traceability throughout the application. Ex. via Kiali dashboard.

NOTE: this is an updated version of a [previous version label PR](https://github.com/kubernetes-sigs/metrics-server/pull/1596) I'd created, and hopefully improved, based on comments from @stevehipwell. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

