### PR TITLE
Replace deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 2m
+  timeout: 10m
 
 linters:
   disable-all: true
@@ -8,7 +8,7 @@ linters:
     - dogsled
     - dupl
     - errcheck
-    - exportloopref
+    - copyloopvar
     - exhaustive
     - gocritic
     - gocyclo
@@ -22,7 +22,6 @@ linters:
     - nakedret
     - nolintlint
     - staticcheck
-    - typecheck
     - unconvert
     - unused
     - whitespace

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ALL_BINARIES_PLATFORMS= $(addprefix linux/,$(ALL_ARCHITECTURES)) \
 
 # Tools versions
 # --------------
-GOLANGCI_VERSION:=1.61.0
+GOLANGCI_VERSION:=1.64.8
 
 # Computed variables
 # ------------------
@@ -241,7 +241,7 @@ endif
 
 .PHONY: verify-lint
 verify-lint: golangci
-	$(GOPATH)/bin/golangci-lint run --timeout 10m || (echo 'Run "make update"' && exit 1)
+	$(GOPATH)/bin/golangci-lint run || (echo 'Run "make update"' && exit 1)
 
 .PHONY: update-lint
 update-lint: golangci


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates unsupported configurations of golangci-lint and replaces deprecated linter.

The `exportloopref` has been deprecated from [golangci-lint@v1.60.2](https://github.com/golangci/golangci-lint/releases/tag/v1.60.2) and replaced by `copyloopvar`.

The `typecheck` has been removed from golangci-lint:
```
-bash-5.0# golangci-lint linters | grep typecheck | wc -l 
0
-bash-5.0# 
-bash-5.0# golangci-lint version
golangci-lint has version 1.61.0 built with go1.23.1 from a1d6c560 on 2024-09-09T17:44:42Z
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

