### PR TITLE
chore: bump go to 1.24.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Update the base image in Makefile when updating golang version. This has to
 # be pre-pulled in order to work on GCB.
 ARG ARCH
-FROM golang:1.23.4 as build
+FROM golang:1.24.2 as build
 
 WORKDIR /go/src/sigs.k8s.io/metrics-server
 COPY go.mod .

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ CONTAINER_ARCH_TARGETS=$(addprefix container-,$(ALL_ARCHITECTURES))
 container:
 	# Pull base image explicitly. Keep in sync with Dockerfile, otherwise
 	# GCB builds will start failing.
-	docker pull golang:1.23.4
+	docker pull golang:1.24.2
 	docker build -t $(REGISTRY)/metrics-server-$(ARCH):$(CHECKSUM) --build-arg ARCH=$(ARCH) --build-arg GIT_TAG=$(GIT_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) .
 
 .PHONY: container-all

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/metrics-server
 
-go 1.23.4
+go 1.24.2
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/scripts/go.mod
+++ b/scripts/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/metrics-server/scripts
 
-go 1.23.4
+go 1.24.2
 
 require (
 	github.com/google/addlicense v1.1.1


### PR DESCRIPTION
Supersede https://github.com/kubernetes-sigs/metrics-server/pull/1640 