### PR TITLE
chore: upgrade golangci-lint to 2.1.6

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,21 +1,16 @@
-run:
-  timeout: 10m
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
+    - copyloopvar
     - dogsled
     - dupl
     - errcheck
-    - copyloopvar
     - exhaustive
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
     - goprintffuncname
-    - gosimple
     - govet
     - ineffassign
     - misspell
@@ -25,7 +20,28 @@ linters:
     - unconvert
     - unused
     - whitespace
-
-linters-settings:
-  goimports:
-    local-prefixes: sigs.k8s.io/metrics-server
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - sigs.k8s.io/metrics-server
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ ALL_BINARIES_PLATFORMS= $(addprefix linux/,$(ALL_ARCHITECTURES)) \
 
 # Tools versions
 # --------------
-GOLANGCI_VERSION:=1.64.8
+GOLANGCI_VERSION:=2.1.6
 
 # Computed variables
 # ------------------

--- a/cmd/metrics-server/app/options/kubelet_client.go
+++ b/cmd/metrics-server/app/options/kubelet_client.go
@@ -112,21 +112,21 @@ func (o KubeletClientOptions) Config(restConfig *rest.Config) *client.KubeletCli
 		config.Client.TLSClientConfig = rest.TLSClientConfig{}      // empty TLS config --> no TLS
 	}
 	if o.InsecureKubeletTLS {
-		config.Client.TLSClientConfig.Insecure = true
-		config.Client.TLSClientConfig.CAData = nil
-		config.Client.TLSClientConfig.CAFile = ""
+		config.Client.TLSClientConfig.Insecure = true //nolint:staticcheck
+		config.Client.TLSClientConfig.CAData = nil    //nolint:staticcheck
+		config.Client.TLSClientConfig.CAFile = ""     //nolint:staticcheck
 	}
 	if len(o.KubeletCAFile) > 0 {
-		config.Client.TLSClientConfig.CAFile = o.KubeletCAFile
-		config.Client.TLSClientConfig.CAData = nil
+		config.Client.TLSClientConfig.CAFile = o.KubeletCAFile //nolint:staticcheck
+		config.Client.TLSClientConfig.CAData = nil             //nolint:staticcheck
 	}
 	if len(o.KubeletClientCertFile) > 0 {
-		config.Client.TLSClientConfig.CertFile = o.KubeletClientCertFile
-		config.Client.TLSClientConfig.CertData = nil
+		config.Client.TLSClientConfig.CertFile = o.KubeletClientCertFile //nolint:staticcheck
+		config.Client.TLSClientConfig.CertData = nil                     //nolint:staticcheck
 	}
 	if len(o.KubeletClientKeyFile) > 0 {
-		config.Client.TLSClientConfig.KeyFile = o.KubeletClientKeyFile
-		config.Client.TLSClientConfig.KeyData = nil
+		config.Client.TLSClientConfig.KeyFile = o.KubeletClientKeyFile //nolint:staticcheck
+		config.Client.TLSClientConfig.KeyData = nil                    //nolint:staticcheck
 	}
 	return config
 }

--- a/cmd/metrics-server/app/options/kubelet_client_test.go
+++ b/cmd/metrics-server/app/options/kubelet_client_test.go
@@ -121,8 +121,8 @@ func TestConfig(t *testing.T) {
 			},
 			expectFunc: func() client.KubeletClientConfig {
 				e := expected
-				e.Client.TLSClientConfig.CertFile = "Override"
-				e.Client.TLSClientConfig.CertData = nil
+				e.Client.TLSClientConfig.CertFile = "Override" //nolint:staticcheck
+				e.Client.TLSClientConfig.CertData = nil        //nolint:staticcheck
 				return e
 			},
 		},
@@ -135,8 +135,8 @@ func TestConfig(t *testing.T) {
 			},
 			expectFunc: func() client.KubeletClientConfig {
 				e := expected
-				e.Client.TLSClientConfig.KeyFile = "Override"
-				e.Client.TLSClientConfig.KeyData = nil
+				e.Client.TLSClientConfig.KeyFile = "Override" //nolint:staticcheck
+				e.Client.TLSClientConfig.KeyData = nil        //nolint:staticcheck
 				return e
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Upgrade golangci-lint to 2.1.16
https://golangci-lint.run/product/migration-guide

I believe this could fix the verify test that gets hang currently

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

