### PR TITLE
Display CPU usage in milli cores instead of nano cores for PodMetrics…

### DIFF
--- a/pkg/storage/node_test.go
+++ b/pkg/storage/node_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Node storage", func() {
 		Expect(ms[0].Window.Duration).Should(BeEquivalentTo(10 * time.Second))
 		Expect(ms[0].Usage).Should(BeEquivalentTo(
 			corev1.ResourceList{
-				corev1.ResourceCPU:    *resource.NewScaledQuantity(CoreSecond, -9),
+				corev1.ResourceCPU:    *resource.NewScaledQuantity(1000, -3),
 				corev1.ResourceMemory: *resource.NewQuantity(3*MiByte, resource.BinarySI),
 			},
 		))
@@ -174,7 +174,7 @@ var _ = Describe("Node storage", func() {
 		Expect(ms[0].Window.Duration).Should(BeEquivalentTo(10 * time.Second))
 		Expect(ms[0].Usage).Should(BeEquivalentTo(
 			corev1.ResourceList{
-				corev1.ResourceCPU:    *resource.NewScaledQuantity(2.5*CoreSecond, -9),
+				corev1.ResourceCPU:    *resource.NewScaledQuantity(2500, -3),
 				corev1.ResourceMemory: *resource.NewQuantity(2*MiByte, resource.BinarySI),
 			},
 		))
@@ -203,7 +203,7 @@ var _ = Describe("Node storage", func() {
 		Expect(ms[0].Window.Duration).Should(BeEquivalentTo(10 * time.Second))
 		Expect(ms[0].Usage).Should(BeEquivalentTo(
 			corev1.ResourceList{
-				corev1.ResourceCPU:    *resource.NewScaledQuantity(CoreSecond, -9),
+				corev1.ResourceCPU:    *resource.NewScaledQuantity(1000, -3),
 				corev1.ResourceMemory: *resource.NewQuantity(3*MiByte, resource.BinarySI),
 			},
 		))

--- a/pkg/storage/pod_test.go
+++ b/pkg/storage/pod_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Pod storage", func() {
 		Expect(ms[0].Containers).Should(BeEquivalentTo([]metrics.ContainerMetrics{{
 			Name: "container1",
 			Usage: corev1.ResourceList{
-				corev1.ResourceCPU:    *resource.NewScaledQuantity(1*CoreSecond, -9),
+				corev1.ResourceCPU:    *resource.NewScaledQuantity(1000, -3),
 				corev1.ResourceMemory: *resource.NewQuantity(5*MiByte, resource.BinarySI),
 			},
 		}}))
@@ -168,7 +168,7 @@ var _ = Describe("Pod storage", func() {
 		Expect(ms[0].Containers).Should(BeEquivalentTo([]metrics.ContainerMetrics{{
 			Name: "container1",
 			Usage: corev1.ResourceList{
-				corev1.ResourceCPU:    *resource.NewScaledQuantity(500000000, -9),
+				corev1.ResourceCPU:    *resource.NewScaledQuantity(500, -3),
 				corev1.ResourceMemory: *resource.NewQuantity(5*MiByte, resource.BinarySI),
 			},
 		}}))
@@ -230,7 +230,7 @@ var _ = Describe("Pod storage", func() {
 		Expect(ms[0].Containers).Should(BeEquivalentTo([]metrics.ContainerMetrics{{
 			Name: "container1",
 			Usage: corev1.ResourceList{
-				corev1.ResourceCPU:    *resource.NewScaledQuantity(5*CoreSecond, -9),
+				corev1.ResourceCPU:    *resource.NewScaledQuantity(5000, -3),
 				corev1.ResourceMemory: *resource.NewQuantity(5*MiByte, resource.BinarySI),
 			},
 		}}))
@@ -262,7 +262,7 @@ var _ = Describe("Pod storage", func() {
 		Expect(ms[0].Containers).Should(BeEquivalentTo([]metrics.ContainerMetrics{{
 			Name: "container1",
 			Usage: corev1.ResourceList{
-				corev1.ResourceCPU:    *resource.NewScaledQuantity(1*CoreSecond, -9),
+				corev1.ResourceCPU:    *resource.NewScaledQuantity(1000, -3),
 				corev1.ResourceMemory: *resource.NewQuantity(4*MiByte, resource.BinarySI),
 			},
 		}}))
@@ -313,7 +313,7 @@ var _ = Describe("Pod storage", func() {
 		Expect(ms[0].Containers).Should(BeEquivalentTo([]metrics.ContainerMetrics{{
 			Name: "container1",
 			Usage: corev1.ResourceList{
-				corev1.ResourceCPU:    *resource.NewScaledQuantity(1*CoreSecond, -9),
+				corev1.ResourceCPU:    *resource.NewScaledQuantity(1000, -3),
 				corev1.ResourceMemory: *resource.NewQuantity(5*MiByte, resource.BinarySI),
 			},
 		}}))

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -59,8 +59,9 @@ func resourceUsage(last, prev MetricsPoint) (corev1.ResourceList, api.TimeInfo, 
 	}
 	window := last.Timestamp.Sub(prev.Timestamp)
 	cpuUsage := float64(last.CumulativeCPUUsed-prev.CumulativeCPUUsed) / window.Seconds()
+	millicores := cpuUsage / 1_000_000
 	return corev1.ResourceList{
-			corev1.ResourceCPU:    uint64Quantity(uint64(cpuUsage), resource.DecimalSI, -9),
+			corev1.ResourceCPU:    uint64Quantity(uint64(millicores), resource.DecimalSI, -3),
 			corev1.ResourceMemory: uint64Quantity(last.MemoryUsage, resource.BinarySI, 0),
 		}, api.TimeInfo{
 			Timestamp: last.Timestamp,

--- a/pkg/storage/types_test.go
+++ b/pkg/storage/types_test.go
@@ -59,9 +59,9 @@ func Test_resourceUsage(t *testing.T) {
 	}{
 		{
 			name: "get resource usage successfully",
-			last: newMetricsPoint(start, start.Add(20*time.Millisecond), 500, 600),
-			prev: newMetricsPoint(start, start.Add(10*time.Millisecond), 300, 400),
-			wantResourceList: v1.ResourceList{v1.ResourceCPU: uint64Quantity(uint64(20000), resource.DecimalSI, -9),
+			last: newMetricsPoint(start, start.Add(20*time.Millisecond), 50000000, 600),
+			prev: newMetricsPoint(start, start.Add(10*time.Millisecond), 30000000, 400),
+			wantResourceList: v1.ResourceList{v1.ResourceCPU: uint64Quantity(uint64(2000), resource.DecimalSI, -3),
 				v1.ResourceMemory: uint64Quantity(600, resource.BinarySI, 0)},
 			wantTimeInfo: api.TimeInfo{Timestamp: start.Add(20 * time.Millisecond), Window: 10 * time.Millisecond},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates metrics-server to display CPU usage in milli cores (e.g., `67m`) instead of nano cores (e.g., `67131864n`) in PodMetrics and NodeMetrics outputs. This makes the output more intuitive and aligns with Kubernetes conventions, where milli cores are the standard for CPU resource display.

**Details:**
- Updates the scale in resource usage calculation from -9 (nano) to -3 (milli) in `pkg/storage/types.go`.
- Adjusts all related unit tests to expect milli core values.
- Improves user experience and consistency with other Kubernetes tools.
- No API or data structure changes; only the display format is affected.

**Which issue(s) this PR fixes**:
Fixes #1669