### PR TITLE
Makefile: update test-e2e to run against 1.33

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ test-image-all:
 # -----------
 
 .PHONY: test-e2e
-test-e2e: test-e2e-1.32
+test-e2e: test-e2e-1.33
 
 .PHONY: test-e2e-all
 test-e2e-all: test-e2e-1.33 test-e2e-1.32 test-e2e-1.31


### PR DESCRIPTION
We missed that when adding the new 1.33 target in #1653