### PR TITLE
Add slashpai and RainbowMango as reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,11 +1,10 @@
 # See the OWNERS docs: https://go.k8s.io/owners
 approvers:
-- s-urbaniak
 - serathius
 - dgrisonnet
-- logicalhan
 reviewers:
+- RainbowMango
 - dgrisonnet
-- s-urbaniak
 - serathius
+- slashpai
 - yangjunmyfm192085


### PR DESCRIPTION
Adding both @slashpai and @RainbowMango as reviewers due to their recent contributions and their desire to help maintain the project.

I also removed maintainers that haven't been active for a while.