### PR TITLE
Use repository default branch in chart-testing workflow

### DIFF
--- a/.github/workflows/lint-test-chart.yaml
+++ b/.github/workflows/lint-test-chart.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Check for changes
         id: changes
         run: |
-          changed="$(ct list-changed --target-branch=master)"
+          changed="$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})"
           if [[ -n "${changed}" ]]
           then
             echo "changed=true" >> "${GITHUB_OUTPUT}"
@@ -78,7 +78,7 @@ jobs:
 
       - name: Run chart-testing lint
         if: steps.changes.outputs.changed == 'true'
-        run: ct lint --target-branch=master --check-version-increment=false
+        run: ct lint --check-version-increment=false --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Create Kind cluster
         if: steps.changes.outputs.changed == 'true'
@@ -120,4 +120,4 @@ jobs:
 
       - name: Run chart-testing install
         if: steps.changes.outputs.changed == 'true'
-        run: ct install --target-branch=master --namespace kube-system
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --namespace kube-system


### PR DESCRIPTION
**What this PR does / why we need it**:
~~Bump helm/chart-testing-action to v2.7.0, to replace #1638 as explained at https://github.com/kubernetes-sigs/metrics-server/pull/1638#issuecomment-3073489071~~

This PR updates the `.github/workflows/lint-test-chart.yaml` workflow to use the repository’s default branch `(${{ github.event.repository.default_branch }})` instead of hardcoding `master` as the target branch for chart-testing commands. This change improves compatibility for repositories that use a different default branch name (such as `main`), making the workflow more flexible and future-proof.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

