### PR TITLE
#1709 - Add commonName to dnsNames in Certificate manifest to comply with ACME

### DIFF
--- a/charts/metrics-server/templates/certificate.yaml
+++ b/charts/metrics-server/templates/certificate.yaml
@@ -19,6 +19,7 @@ metadata:
 spec:
   commonName: {{ include "metrics-server.fullname" . }}
   dnsNames:
+  - {{ include "metrics-server.fullname" . }}
   - {{ include "metrics-server.fullname" . }}.{{ .Release.Namespace }}
   - {{ include "metrics-server.fullname" . }}.{{ .Release.Namespace }}.svc
   - {{ include "metrics-server.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.tls.clusterDomain }}


### PR DESCRIPTION
This PR updates the Helm chart’s `Certificate` manifest to include the `commonName` in the `dnsNames` list.  
Currently, cert-manager issues a warning and ACME rejects the CSR because the `commonName` (`metrics-server`) is not present in the SANs list.  
By ensuring the `commonName` is also included under `dnsNames`, the certificate request complies with ACME requirements for cert-manager.

Fixes #1709 