### PR TITLE
Fix chart empty annotations in APIService

### DIFF
--- a/charts/metrics-server/templates/apiservice.yaml
+++ b/charts/metrics-server/templates/apiservice.yaml
@@ -38,7 +38,7 @@ metadata:
   name: v1beta1.metrics.k8s.io
   labels:
     {{- include "metrics-server.labels" . | nindent 4 }}
-  {{- if or .Values.apiService.annotations .Values.tls.certManager.addInjectorAnnotations }}
+  {{- if or .Values.apiService.annotations (and .Values.tls.certManager.addInjectorAnnotations (eq .Values.tls.type "cert-manager")) }}
   annotations:
     {{- if and (eq .Values.tls.type "cert-manager") .Values.tls.certManager.addInjectorAnnotations }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "metrics-server.fullname" . }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Latest chart version adds empty (null) `annotations` to APIService object.

This causes problem (constant diff) when metrics servers is deployed from ArgoCD using helm chart.

What causes this:
1. helm template produces such yaml
```yaml
---
apiVersion: apiregistration.k8s.io/v1
kind: APIService
metadata:
  name: v1beta1.metrics.k8s.io
  labels:
    helm.sh/chart: metrics-server-3.13.0
    app.kubernetes.io/name: metrics-server
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "0.8.0"
    app.kubernetes.io/managed-by: Helm
spec:
  group: metrics.k8s.io
  groupPriorityMinimum: 100
  insecureSkipTLSVerify: true
  service:
    name: test-metrics-server
    namespace: default
    port: 443
  version: v1beta1
  versionPriority: 100
```
1. After applying this yaml to Kubernetes, api server removes empty `annotations:`
1. ArgoCD sees diff and tries to apply again and cycle repeats.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
