### PR TITLE
fix: conditionally render insecureSkipTLSVerify in APIService template

### DIFF
--- a/charts/metrics-server/CHANGELOG.md
+++ b/charts/metrics-server/CHANGELOG.md
@@ -14,7 +14,11 @@
 
 ## [UNRELEASED]
 
-## [3.13.0] - TBC
+### Fixed
+
+- Conditionally render `insecureSkipTLSVerify` field in APIService template to prevent GitOps sync drift when value is `false`. ([#1727](https://github.com/kubernetes-sigs/metrics-server/pull/1727)) _@pawl_
+
+## [3.13.0] - 2025-07-22
 
 ### Added
 

--- a/charts/metrics-server/templates/apiservice.yaml
+++ b/charts/metrics-server/templates/apiservice.yaml
@@ -61,7 +61,9 @@ spec:
   {{- end }}
   group: metrics.k8s.io
   groupPriorityMinimum: 100
-  insecureSkipTLSVerify: {{ .Values.apiService.insecureSkipTLSVerify }}
+{{- with .Values.apiService.insecureSkipTLSVerify }}
+  insecureSkipTLSVerify: {{ . }}
+{{- end }}
   service:
     name: {{ include "metrics-server.fullname" . }}
     namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes GitOps sync drift caused by the APIService template unconditionally rendering the `insecureSkipTLSVerify` field.

**Problem**: When `apiService.insecureSkipTLSVerify: false` is set in values, Kubernetes omits this field from live resources (since `false` is the API default), but the Helm template always renders it explicitly. This causes a continuous diff between desired state (Helm template) and live state (Kubernetes API), leading GitOps tools like ArgoCD to show the APIService as "OutOfSync".

**Solution**: Implement conditional rendering using `{{- if .Values.apiService.insecureSkipTLSVerify }}` to only include the field when the value is `true`. This matches the approach used by other projects like [KEDA that encountered the same issue](https://github.com/kedacore/keda/discussions/5123).

**Which issue(s) this PR fixes**:
Fixes #1725

**Testing**:
The existing chart CI will verify this change works correctly:
- Helm chart linting and template validation via `chart-testing`
- Installation testing with `insecureSkipTLSVerify: false` in multiple scenarios:
  - `ci/tls-certManager-values.yaml` (cert-manager TLS)
  - `ci/tls-helm-values.yaml` (helm-generated TLS)
  - `ci/tls-existingSecret-values.yaml` (existing secret TLS, set dynamically)
- Real cluster deployment testing to ensure APIService creation succeeds

**Release note**:
```release-note
Fix APIService template to conditionally render insecureSkipTLSVerify field, preventing GitOps sync drift when value is false
```