### PR TITLE
helm-release: Publish the helm chart as OCI artifact

### DIFF
--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -18,8 +18,12 @@ jobs:
     defaults:
       run:
         shell: bash
+
     permissions:
       contents: write
+      packages: write
+      id-token: write
+      
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
@@ -93,3 +97,34 @@ jobs:
           CR_RELEASE_NAME_TEMPLATE: "metrics-server-helm-chart-{{ .Version }}"
           CR_RELEASE_NOTES_FILE: RELEASE.md
           CR_MAKE_RELEASE_LATEST: false
+
+      - name: Setup cosign
+        uses: sigstore/cosign-installer@v4.0.0
+        with:
+          cosign-release: v3.0.2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push charts to GHCR and sign
+        # when filling gaps with previously released charts, cr would create
+        # nothing in .cr-release-packages/, and the original globbing character
+        # would be preserved, causing a non-zero exit. Set nullglob to fix this
+        run: |
+          shopt -s nullglob
+          for pkg in .cr-release-packages/*; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" oci://ghcr.io/"${GITHUB_REPOSITORY_OWNER}"/charts |& tee .digest
+            file="${pkg##*/}"       # extracts file name from full directory path
+            name="${file%-*}"       # extracts chart name from filename
+            digest="$(awk -F "[, ]+" '/Digest/{print $NF}' < .digest)"
+            cosign sign ghcr.io/"${GITHUB_REPOSITORY_OWNER}"/charts/"${name}"@"${digest}"
+          done
+        env:
+          COSIGN_YES: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR will ensure whenever a new release of the chart is published it will also be published as OCI.

the chart will be published at `ghcr.io/kubernetes-sigs/charts/metrics-server`

This is useful for folks that use ECR caching in local regions for faster argocd syncs.

Same is used for couple of years here https://github.com/spiffe/helm-charts-hardened/blob/spire-0.26.1/.github/workflows/helm-release.yaml#L53-L70

Also see https://github.com/kubernetes-sigs/cluster-proportional-autoscaler/pull/268

> [!Note]
> As the original helm release isn't touched that part of the release will not be affected. Only if the http release succeeds the workflow will try to also publish this OCI release.
>
> The risk therefore is very low.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

N.A.
