### PR TITLE
Bump Golang version to v1.24.10 to address CVE-2025-47907, CVE-2025-47906

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Update the base image in Makefile when updating golang version. This has to
 # be pre-pulled in order to work on GCB.
 ARG ARCH
-FROM golang:1.24.5 as build
+FROM golang:1.24.10 as build
 
 WORKDIR /go/src/sigs.k8s.io/metrics-server
 COPY go.mod .

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ CONTAINER_ARCH_TARGETS=$(addprefix container-,$(ALL_ARCHITECTURES))
 container:
 	# Pull base image explicitly. Keep in sync with Dockerfile, otherwise
 	# GCB builds will start failing.
-	${CONTAINER_CLI} pull golang:1.24.5
+	${CONTAINER_CLI} pull golang:1.24.10
 	${CONTAINER_CLI} build -t $(REGISTRY)/metrics-server-$(ARCH):$(CHECKSUM) --build-arg ARCH=$(ARCH) --build-arg GIT_TAG=$(GIT_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) .
 
 .PHONY: container-all

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/metrics-server
 
-go 1.24.5
+go 1.24.10
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR bumps Golang to v1.24.10 to address CVE concerns as described at #1730.

**Which issue(s) this PR fixes** :
Fixes #1730

