### PR TITLE
fix(chart): do not render annotations as null in APIService template

### DIFF
--- a/charts/metrics-server/CHANGELOG.md
+++ b/charts/metrics-server/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixed
 
 - Conditionally render `insecureSkipTLSVerify` field in APIService template to prevent GitOps sync drift when value is `false`. ([#1727](https://github.com/kubernetes-sigs/metrics-server/pull/1727)) _@pawl_
+- Do not render annotations as null in APIService template to prevent permanent OutOfSync in ArgoCD. ([#1752](https://github.com/kubernetes-sigs/metrics-server/pull/1752)) _@Serializator_
 
 ## [3.13.0] - 2025-07-22
 

--- a/charts/metrics-server/templates/apiservice.yaml
+++ b/charts/metrics-server/templates/apiservice.yaml
@@ -38,9 +38,10 @@ metadata:
   name: v1beta1.metrics.k8s.io
   labels:
     {{- include "metrics-server.labels" . | nindent 4 }}
-  {{- if or .Values.apiService.annotations .Values.tls.certManager.addInjectorAnnotations }}
+  {{- $includeCertManagerAnnotations := (and .Values.tls.certManager.addInjectorAnnotations (eq .Values.tls.type "cert-manager")) }}
+  {{- if or .Values.apiService.annotations $includeCertManagerAnnotations }}
   annotations:
-    {{- if and (eq .Values.tls.type "cert-manager") .Values.tls.certManager.addInjectorAnnotations }}
+    {{- if $includeCertManagerAnnotations }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "metrics-server.fullname" . }}
     {{- end }}
     {{- with .Values.apiService.annotations }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Annotations in the APIService template are rendered as `null` when:

- `.Values.tls.certManager.addInjectorAnnotations` is set to `true`
- `.Values.tls.type` is not equal to `"cert-manager"`

This PR extends the conditional with the same `.Values.tls.type` check to avoid rendering annotations as `null`.

**Which issue(s) this PR fixes**:
Fixes #1689

