### PR TITLE
feat(chart): add automountServiceAccountToken support, more commonAnnotations

### DIFF
--- a/charts/metrics-server/templates/apiservice.yaml
+++ b/charts/metrics-server/templates/apiservice.yaml
@@ -38,14 +38,14 @@ metadata:
   name: v1beta1.metrics.k8s.io
   labels:
     {{- include "metrics-server.labels" . | nindent 4 }}
-  {{- if or .Values.apiService.annotations .Values.tls.certManager.addInjectorAnnotations }}
+  {{- $certManagerAnnotations := dict }}
+  {{- if and (eq .Values.tls.type "cert-manager") .Values.tls.certManager.addInjectorAnnotations }}
+  {{- $certManagerAnnotations = dict "cert-manager.io/inject-ca-from" (printf "%s/%s" .Release.Namespace (include "metrics-server.fullname" .)) }}
+  {{- end }}
+  {{- $annotations := mustMergeOverwrite (dict) (.Values.commonAnnotations | default dict) (.Values.apiService.annotations | default dict) $certManagerAnnotations }}
+  {{- if $annotations }}
   annotations:
-    {{- if and (eq .Values.tls.type "cert-manager") .Values.tls.certManager.addInjectorAnnotations }}
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "metrics-server.fullname" . }}
-    {{- end }}
-    {{- with .Values.apiService.annotations }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- toYaml $annotations | nindent 4 }}
   {{- end }}
 spec:
   {{- if eq .Values.tls.type "helm" }}

--- a/charts/metrics-server/templates/clusterrole-aggregated-reader.yaml
+++ b/charts/metrics-server/templates/clusterrole-aggregated-reader.yaml
@@ -8,6 +8,10 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups:
       - metrics.k8s.io

--- a/charts/metrics-server/templates/clusterrole.yaml
+++ b/charts/metrics-server/templates/clusterrole.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ printf "system:%s" (include "metrics-server.fullname" .) }}
   labels:
     {{- include "metrics-server.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups:
     - ""

--- a/charts/metrics-server/templates/clusterrolebinding-auth-delegator.yaml
+++ b/charts/metrics-server/templates/clusterrolebinding-auth-delegator.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ printf "%s:system:auth-delegator" (include "metrics-server.fullname" .) }}
   labels:
     {{- include "metrics-server.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/metrics-server/templates/clusterrolebinding.yaml
+++ b/charts/metrics-server/templates/clusterrolebinding.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ printf "system:%s" (include "metrics-server.fullname" .) }}
   labels:
     {{- include "metrics-server.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/metrics-server/templates/deployment.yaml
+++ b/charts/metrics-server/templates/deployment.yaml
@@ -5,9 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "metrics-server.labels" . | nindent 4 }}
-  {{- with .Values.deploymentAnnotations }}
+  {{- $annotations := mustMergeOverwrite (dict) (.Values.commonAnnotations | default dict) (.Values.deploymentAnnotations | default dict) }}
+  {{- if $annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml $annotations | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.replicas }}
@@ -64,10 +65,10 @@ spec:
           image: {{ include "metrics-server.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - {{ printf "--secure-port=%d" (int .Values.containerPort) }}
           {{- range .Values.defaultArgs }}
             - {{ . }}
           {{- end }}
+            - {{ printf "--secure-port=%d" (int .Values.containerPort) }}
           {{- if .Values.metrics.enabled }}
             - --authorization-always-allow-paths=/metrics
           {{- end }}

--- a/charts/metrics-server/templates/pdb.yaml
+++ b/charts/metrics-server/templates/pdb.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "metrics-server.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}

--- a/charts/metrics-server/templates/rolebinding.yaml
+++ b/charts/metrics-server/templates/rolebinding.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: kube-system
   labels:
     {{- include "metrics-server.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/metrics-server/templates/service.yaml
+++ b/charts/metrics-server/templates/service.yaml
@@ -8,9 +8,10 @@ metadata:
   {{- with .Values.service.labels -}}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.service.annotations }}
+  {{- $annotations := mustMergeOverwrite (dict) (.Values.commonAnnotations | default dict) (.Values.service.annotations | default dict) }}
+  {{- if $annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml $annotations | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/charts/metrics-server/templates/serviceaccount.yaml
+++ b/charts/metrics-server/templates/serviceaccount.yaml
@@ -6,10 +6,14 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "metrics-server.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- $annotations := mustMergeOverwrite (dict) (.Values.commonAnnotations | default dict) (.Values.serviceAccount.annotations | default dict) }}
+  {{- if $annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml $annotations | nindent 4 }}
   {{- end }}
+{{- if hasKey .Values.serviceAccount "automountServiceAccountToken" }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- with .Values.serviceAccount.secrets }}
 secrets:
   {{- toYaml . | nindent 2 }}

--- a/charts/metrics-server/values.yaml
+++ b/charts/metrics-server/values.yaml
@@ -25,6 +25,9 @@ serviceAccount:
   # The list of secrets mountable by this service account.
   # See https://kubernetes.io/docs/reference/labels-annotations-taints/#enforce-mountable-secrets
   secrets: []
+  # Specifies whether to automount the service account token
+  # When not set, Kubernetes default (true) is used
+  # automountServiceAccountToken: true
 
 rbac:
   # Specifies whether RBAC resources should be created
@@ -47,6 +50,8 @@ apiService:
   caBundle: ""
 
 commonLabels: {}
+# Annotations to add to all resources
+commonAnnotations: {}
 podLabels: {}
 podAnnotations: {}
 


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it:

This PR adds two new features to the Helm chart:

### 1. `serviceAccount.automountServiceAccountToken`

Allows controlling whether the service account token is automatically mounted. This is useful for security hardening when using projected volumes for manual token access instead of automatic mounting.

**Usage:**
```yaml
serviceAccount:
  automountServiceAccountToken: false
```

Only renders when explicitly set, preserving default Kubernetes behavior (no diff when omitted).

### 2. `commonAnnotations`

Adds the ability to specify annotations that will be applied to **all** resources created by the chart. This is useful for:
- Organizational metadata
- Ownership tracking  
- Policy enforcement (e.g., cost allocation, compliance)

**Usage:**
```yaml
commonAnnotations:
  my-org.com/owner: platform-team
  my-org.com/cost-center: "12345"
```

Applied to: ServiceAccount, ClusterRoles, ClusterRoleBindings, RoleBinding, Service, Deployment, PDB, APIService.

### 3. Arg ordering improvement

Moves `--secure-port` arg after `defaultArgs` for better flexibility when users need to control argument ordering.
Required when using a custom image and entry point and need to specify metrics-server binary.

## Which issue(s) this PR fixes:

None - new feature request.

## Special notes for your reviewer:

- All changes are backward compatible
- No `Chart.yaml` modifications per contributing guidelines
- When `automountServiceAccountToken` is not set, no diff is produced (uses Kubernetes default)
- `commonAnnotations` is merged with resource-specific annotations (e.g., `service.annotations`), with resource-specific taking precedence

## Does this PR introduce a user-facing change?

```release-note
chart: Add serviceAccount.automountServiceAccountToken and commonAnnotations support
```
****