### PR TITLE
docs: clarify kube-apiserver version skew policy in compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ Metrics Server | Metrics API group/version | Supported Kubernetes version
 0.4.x          | `metrics.k8s.io/v1beta1`  | *1.8+
 0.3.x          | `metrics.k8s.io/v1beta1`  | 1.8-1.21
 
+### kube-apiserver Version Skew
+
+Metrics Server follows the Kubernetes Version Skew Policy.
+
+The kube-apiserver version must be within the supported Kubernetes version range listed in the Compatibility Matrix above.
+
+For full details, refer to the official Kubernetes Version Skew Policy:
+https://kubernetes.io/releases/version-skew-policy/
+
 *Kubernetes versions lower than v1.16 require passing the `--authorization-always-allow-paths=/livez,/readyz` command line flag
 
 ### High Availability

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Metrics Server | Metrics API group/version | Supported Kubernetes version
 0.4.x          | `metrics.k8s.io/v1beta1`  | *1.8+
 0.3.x          | `metrics.k8s.io/v1beta1`  | 1.8-1.21
 
+*Kubernetes versions lower than v1.16 require passing the `--authorization-always-allow-paths=/livez,/readyz` command line flag
+
 ### kube-apiserver Version Skew
 
 Metrics Server follows the Kubernetes Version Skew Policy.
@@ -88,7 +90,6 @@ The kube-apiserver version must be within the supported Kubernetes version range
 For full details, refer to the official Kubernetes Version Skew Policy:
 https://kubernetes.io/releases/version-skew-policy/
 
-*Kubernetes versions lower than v1.16 require passing the `--authorization-always-allow-paths=/livez,/readyz` command line flag
 
 ### High Availability
 


### PR DESCRIPTION
This PR clarifies kube-apiserver version skew expectations in the Compatibility Matrix section of the README.

Instead of duplicating skew details in the table, it references the official Kubernetes Version Skew Policy to prevent documentation drift and ensure long-term accuracy.

**What this PR does / why we need it**:

Adds a dedicated section referencing the Kubernetes Version Skew Policy to clarify kube-apiserver compatibility expectations without duplicating skew values in the compatibility table.

**Which issue(s) this PR fixes**:

Fixes #1484