### PR TITLE
Prefer most recent start time on duplicate Pod metrics

### DIFF
--- a/pkg/scraper/scraper.go
+++ b/pkg/scraper/scraper.go
@@ -168,9 +168,16 @@ func (c *scraper) Scrape(baseCtx context.Context) *storage.MetricsBatch {
 			res.Nodes[nodeName] = nodeMetricsPoint
 		}
 		for podRef, podMetricsPoint := range srcBatch.Pods {
-			if _, podFind := res.Pods[podRef]; podFind {
-				klog.ErrorS(nil, "Got duplicate pod point", "pod", klog.KRef(podRef.Namespace, podRef.Name))
-				continue
+			if existing, podFind := res.Pods[podRef]; podFind {
+				// We have found duplicate metrics for the same Pod so we use the Pod with the
+				// latest container start time and assume the other Pod metrics are stale:
+				// https://github.com/kubernetes-sigs/metrics-server/pull/1778
+				if latestContainerStartTime(podMetricsPoint).After(latestContainerStartTime(existing)) {
+					klog.InfoS("Got duplicate pod point, replacing with newer", "pod", klog.KRef(podRef.Namespace, podRef.Name))
+				} else {
+					klog.InfoS("Got duplicate pod point, keeping existing", "pod", klog.KRef(podRef.Namespace, podRef.Name))
+					continue
+				}
 			}
 			res.Pods[podRef] = podMetricsPoint
 		}
@@ -194,6 +201,16 @@ func (c *scraper) collectNode(ctx context.Context, node *corev1.Node) (*storage.
 	}
 	requestTotal.WithLabelValues("true").Inc()
 	return ms, nil
+}
+
+func latestContainerStartTime(p storage.PodMetricsPoint) time.Time {
+	var latest time.Time
+	for _, c := range p.Containers {
+		if c.StartTime.After(latest) {
+			latest = c.StartTime
+		}
+	}
+	return latest
 }
 
 type clock interface {

--- a/pkg/scraper/scraper.go
+++ b/pkg/scraper/scraper.go
@@ -170,12 +170,11 @@ func (c *scraper) Scrape(baseCtx context.Context) *storage.MetricsBatch {
 		for podRef, podMetricsPoint := range srcBatch.Pods {
 			if existing, podFind := res.Pods[podRef]; podFind {
 				// We have found duplicate metrics for the same Pod so we use the Pod with the
-				// latest container start time and assume the other Pod metrics are stale:
-				// https://github.com/kubernetes-sigs/metrics-server/pull/1778
+				// latest container start time and assume the other Pod metrics are stale
 				if latestContainerStartTime(podMetricsPoint).After(latestContainerStartTime(existing)) {
-					klog.InfoS("Got duplicate pod point, replacing with newer", "pod", klog.KRef(podRef.Namespace, podRef.Name))
+					klog.ErrorS(nil, "Got duplicate pod point, replacing with newer", "pod", klog.KRef(podRef.Namespace, podRef.Name))
 				} else {
-					klog.InfoS("Got duplicate pod point, keeping existing", "pod", klog.KRef(podRef.Namespace, podRef.Name))
+					klog.ErrorS(nil, "Got duplicate pod point, keeping existing", "pod", klog.KRef(podRef.Namespace, podRef.Name))
 					continue
 				}
 			}

--- a/pkg/scraper/scraper_test.go
+++ b/pkg/scraper/scraper_test.go
@@ -88,7 +88,18 @@ var _ = Describe("Scraper", func() {
 				node1: mb,
 				node2: {Nodes: map[string]storage.MetricsPoint{node2.Name: metricPoint(100, 200, scrapeTime)}},
 				node3: {Nodes: map[string]storage.MetricsPoint{node3.Name: metricPoint(100, 200, scrapeTime)}},
-				node4: {Nodes: map[string]storage.MetricsPoint{node4.Name: metricPoint(100, 200, scrapeTime)}},
+				// node4 returns a duplicate Pod ns1/pod1 (also on node1) with a newer container
+				// StartTime to test that the scraper always keeps the most recent instance
+				node4: {
+					Nodes: map[string]storage.MetricsPoint{node4.Name: metricPoint(100, 200, scrapeTime)},
+					Pods: map[apitypes.NamespacedName]storage.PodMetricsPoint{
+						{Namespace: "ns1", Name: "pod1"}: {
+							Containers: map[string]storage.MetricsPoint{
+								"container1": {StartTime: scrapeTime, Timestamp: scrapeTime, CumulativeCPUUsed: 999, MemoryUsage: 999},
+							},
+						},
+					},
+				},
 			},
 		}
 
@@ -133,7 +144,7 @@ var _ = Describe("Scraper", func() {
 
 			By("ensuring that an error and partial results (data from source 2) were returned")
 			Expect(nodeNames(dataBatch)).To(ConsistOf([]string{"node-no-host", "node3", "node4"}))
-			Expect(podNames(dataBatch)).To(BeEmpty())
+			Expect(podNames(dataBatch)).To(ConsistOf([]string{"ns1/pod1"}))
 		})
 
 		It("should respect the parent context's general timeout, even with a longer scrape timeout", func() {
@@ -225,6 +236,16 @@ var _ = Describe("Scraper", func() {
 
 		By("running the scraper")
 		scraper.Scrape(context.Background())
+	})
+	It("should keep the pod with the latest container start time on duplicates", func() {
+		By("running the scraper")
+		scraper := NewScraper(&nodeLister, &client, 5*time.Second, labelRequirement)
+
+		By("ensuring the pod with the newer start time is kept")
+		batch := scraper.Scrape(context.Background())
+		podKey := apitypes.NamespacedName{Namespace: "ns1", Name: "pod1"}
+		Expect(batch.Pods).To(HaveKey(podKey))
+		Expect(batch.Pods[podKey].Containers["container1"].CumulativeCPUUsed).To(Equal(uint64(999)))
 	})
 })
 

--- a/pkg/scraper/scraper_test.go
+++ b/pkg/scraper/scraper_test.go
@@ -88,18 +88,7 @@ var _ = Describe("Scraper", func() {
 				node1: mb,
 				node2: {Nodes: map[string]storage.MetricsPoint{node2.Name: metricPoint(100, 200, scrapeTime)}},
 				node3: {Nodes: map[string]storage.MetricsPoint{node3.Name: metricPoint(100, 200, scrapeTime)}},
-				// node4 returns a duplicate Pod ns1/pod1 (also on node1) with a newer container
-				// StartTime to test that the scraper always keeps the most recent instance
-				node4: {
-					Nodes: map[string]storage.MetricsPoint{node4.Name: metricPoint(100, 200, scrapeTime)},
-					Pods: map[apitypes.NamespacedName]storage.PodMetricsPoint{
-						{Namespace: "ns1", Name: "pod1"}: {
-							Containers: map[string]storage.MetricsPoint{
-								"container1": {StartTime: scrapeTime, Timestamp: scrapeTime, CumulativeCPUUsed: 999, MemoryUsage: 999},
-							},
-						},
-					},
-				},
+				node4: {Nodes: map[string]storage.MetricsPoint{node4.Name: metricPoint(100, 200, scrapeTime)}},
 			},
 		}
 
@@ -144,7 +133,7 @@ var _ = Describe("Scraper", func() {
 
 			By("ensuring that an error and partial results (data from source 2) were returned")
 			Expect(nodeNames(dataBatch)).To(ConsistOf([]string{"node-no-host", "node3", "node4"}))
-			Expect(podNames(dataBatch)).To(ConsistOf([]string{"ns1/pod1"}))
+			Expect(podNames(dataBatch)).To(BeEmpty())
 		})
 
 		It("should respect the parent context's general timeout, even with a longer scrape timeout", func() {
@@ -238,19 +227,39 @@ var _ = Describe("Scraper", func() {
 		scraper.Scrape(context.Background())
 	})
 	It("should keep the pod with the latest container start time on duplicates", func() {
-		By("running the scraper")
+		By("adding duplicate metrics for one of node1's pods to node4 with a later container start time")
+		var podKey apitypes.NamespacedName
+		var containerName string
+		var containerLatestStartTime time.Time
+		for podKey = range client.metrics[node1].Pods {
+			for containerName = range client.metrics[node1].Pods[podKey].Containers {
+				containerStartTime := client.metrics[node1].Pods[podKey].Containers[containerName].StartTime
+				if containerLatestStartTime.Before(containerStartTime) {
+					containerLatestStartTime = containerStartTime
+				}
+			}
+			break
+		}
+		duplicatePodMetrics := storage.PodMetricsPoint{
+			// Set container start time to a later time than on node1
+			Containers: map[string]storage.MetricsPoint{containerName: metricPoint(999, 999, containerLatestStartTime.Add(time.Second))},
+		}
+		client.metrics[node4].Pods = map[apitypes.NamespacedName]storage.PodMetricsPoint{
+			podKey: duplicatePodMetrics,
+		}
 		scraper := NewScraper(&nodeLister, &client, 5*time.Second, labelRequirement)
 
-		By("ensuring the pod with the newer start time is kept")
-		batch := scraper.Scrape(context.Background())
-		podKey := apitypes.NamespacedName{Namespace: "ns1", Name: "pod1"}
-		Expect(batch.Pods).To(HaveKey(podKey))
-		Expect(batch.Pods[podKey].Containers["container1"].CumulativeCPUUsed).To(Equal(uint64(999)))
+		By("running the scraper")
+		dataBatch := scraper.Scrape(context.Background())
+
+		By("ensuring node4's newer metrics are the ones kept")
+		Expect(dataBatch.Pods).To(HaveKeyWithValue(podKey, duplicatePodMetrics))
 	})
 })
 
 func metricPoint(cpu, memory uint64, time time.Time) storage.MetricsPoint {
 	return storage.MetricsPoint{
+		StartTime:         time,
 		Timestamp:         time,
 		CumulativeCPUUsed: cpu,
 		MemoryUsage:       memory,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

There are situations when Metrics Server can scrape duplicate Pod metrics from different nodes (e.g. kubelet metrics have become stale on a particular node due to some garbage collection bug). In this case Metrics Server ignores the duplicate: https://github.com/kubernetes-sigs/metrics-server/blob/78192ed59fca18aa82c64a206a47d97e9f078919/pkg/scraper/scraper.go#L171-L174

However, because Metrics Server scrapes Pod metrics from each node in parallel, the metrics that we end up using for calculating utilisation is fairly random and can change from scrape to scrape due to small request latency differences. This can lead to utilisation changing dramatically from scrape to scrape (e.g. in the case of CPU we get utilisation of 0 if we scrape the stale node first twice in a row, or we don't get any metrics at all if we scrape the current node and then the stale node due to [this](https://github.com/kubernetes-sigs/metrics-server/pull/1300/changes) PR).

Instead, this PR uses the metrics corresponding to the Pod with the latest container start time.

I am running this PR in our dev environment and it is allowing Metrics Server to carry on providing accurate information despite kubelet serving stale metrics.