### PR TITLE
Prefer highest value on duplicate container metrics

### DIFF
--- a/pkg/scraper/client/resource/decode.go
+++ b/pkg/scraper/client/resource/decode.go
@@ -134,9 +134,14 @@ func parseContainerCPUMetrics(namespaceName apitypes.NamespacedName, containerNa
 	if _, findContainer := pods[namespaceName].Containers[containerName]; !findContainer {
 		pods[namespaceName].Containers[containerName] = storage.MetricsPoint{}
 	}
-	// unit of node_cpu_usage_seconds_total is second, need to convert to nanosecond
 	containerMetrics := pods[namespaceName].Containers[containerName]
-	containerMetrics.CumulativeCPUUsed = uint64(value * 1e9)
+	// unit of container_cpu_usage_seconds_total is second, need to convert to nanosecond
+	newCumulativeCPUUsed := uint64(value * 1e9)
+	// If we already have CPU data use the highest value
+	if containerMetrics.CumulativeCPUUsed > newCumulativeCPUUsed {
+		return
+	}
+	containerMetrics.CumulativeCPUUsed = newCumulativeCPUUsed
 	// unit of timestamp is millisecond, need to convert to nanosecond
 	containerMetrics.Timestamp = time.Unix(0, timestamp*1e6)
 	pods[namespaceName].Containers[containerName] = containerMetrics
@@ -150,7 +155,12 @@ func parseContainerMemMetrics(namespaceName apitypes.NamespacedName, containerNa
 		pods[namespaceName].Containers[containerName] = storage.MetricsPoint{}
 	}
 	containerMetrics := pods[namespaceName].Containers[containerName]
-	containerMetrics.MemoryUsage = uint64(value)
+	newMemoryUsage := uint64(value)
+	// If we already have memory data use the highest value
+	if containerMetrics.MemoryUsage > newMemoryUsage {
+		return
+	}
+	containerMetrics.MemoryUsage = newMemoryUsage
 	// unit of timestamp is millisecond, need to convert to nanosecond
 	containerMetrics.Timestamp = time.Unix(0, timestamp*1e6)
 	pods[namespaceName].Containers[containerName] = containerMetrics
@@ -164,7 +174,12 @@ func parseContainerStartTimeMetrics(namespaceName apitypes.NamespacedName, conta
 		pods[namespaceName].Containers[containerName] = storage.MetricsPoint{}
 	}
 	containerMetrics := pods[namespaceName].Containers[containerName]
-	containerMetrics.StartTime = time.Unix(0, int64(value*1e9))
+	newStartTime := time.Unix(0, int64(value*1e9))
+	// If we already have start time data use the highest value
+	if containerMetrics.StartTime.After(newStartTime) {
+		return
+	}
+	containerMetrics.StartTime = newStartTime
 	pods[namespaceName].Containers[containerName] = containerMetrics
 }
 

--- a/pkg/scraper/client/resource/decode_test.go
+++ b/pkg/scraper/client/resource/decode_test.go
@@ -221,6 +221,32 @@ node_memory_working_set_bytes 0 1633253809720
 			expectMetrics: &emptyMetrics,
 		},
 		{
+			name: "Duplicate container metrics keep highest values",
+			input: `
+container_cpu_usage_seconds_total{container="prometheus",namespace="monitoring-system",pod="prometheus-prometheus-k8s-0"} 994631.562157 1773934038841
+container_cpu_usage_seconds_total{container="prometheus",namespace="monitoring-system",pod="prometheus-prometheus-k8s-0"} 295207.606798 1773934038962
+container_memory_working_set_bytes{container="prometheus",namespace="monitoring-system",pod="prometheus-prometheus-k8s-0"} 5.690306969e+10 1773934038841
+container_memory_working_set_bytes{container="prometheus",namespace="monitoring-system",pod="prometheus-prometheus-k8s-0"} 3.3157259264e+10 1773934038962
+container_start_time_seconds{container="prometheus",namespace="monitoring-system",pod="prometheus-prometheus-k8s-0"} 1.7691949565992033e+09
+container_start_time_seconds{container="prometheus",namespace="monitoring-system",pod="prometheus-prometheus-k8s-0"} 1.7691949565992032e+09
+`,
+			expectMetrics: &storage.MetricsBatch{
+				Nodes: map[string]storage.MetricsPoint{},
+				Pods: map[apitypes.NamespacedName]storage.PodMetricsPoint{
+					{Name: "prometheus-prometheus-k8s-0", Namespace: "monitoring-system"}: {
+						Containers: map[string]storage.MetricsPoint{
+							"prometheus": {
+								Timestamp:         time.Unix(0, 1773934038841*1e6),
+								CumulativeCPUUsed: 994631562157000,
+								MemoryUsage:       56903069690,
+								StartTime:         time.Unix(0, int64(float64(1.7691949565992034e+09)*1e9)),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "Containing an incorrect timestamp",
 			input: `
 # HELP container_start_time_seconds [ALPHA] Start time of the container since unix epoch in seconds


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

If kubelet fails to cleanup cgroups from a previous instance of a container (e.g. due to some zombie process), cAdvisor will continue to expose its metrics (see https://github.com/kubernetes/kubernetes/issues/134518#issuecomment-4091119015 for more details).

The following shows an example of a kubelet v1.30.10 returning multiple metrics for the same container (same namespace/name but different UID):

```
$ kubectl get --raw /api/v1/nodes/[NODE_NAME]/proxy/metrics/resource | grep prometheus-prometheus-k8s-0
...
container_cpu_usage_seconds_total{container="prometheus",namespace="monitoring-system",pod="prometheus-prometheus-k8s-0"} 994631.562157 1773934038841
container_cpu_usage_seconds_total{container="prometheus",namespace="monitoring-system",pod="prometheus-prometheus-k8s-0"} 295207.606798 1773934038962
container_memory_working_set_bytes{container="prometheus",namespace="monitoring-system",pod="prometheus-prometheus-k8s-0"} 5.690306969e+10 1173934038841
container_memory_working_set_bytes{container="prometheus",namespace="monitoring-system",pod="prometheus-prometheus-k8s-0"} 3.3157259264e+10 1773934038962
container_start_time_seconds{container="prometheus",namespace="monitoring-system",pod="prometheus-prometheus-k8s-0"} 1.7691949565992033e+09
```

Currently Metrics Server will silently override these duplicates giving unpredictable results. This PR improves consistency by always picking the highest value when there are duplicates. In particular, if we are using these metrics to scale memory vertically with VPA, we prefer to overprovision than underpovision.

Note that doing this with CPU does not necessarily help since it is calculated as a rate, however we do this anyway just to make the response consistent (and once `container_cpu_usage_seconds_total` for a new instance catches up with the old one CPU utilisation for the latest container instance will be calculated properly).

This PR coupled with https://github.com/kubernetes-sigs/metrics-server/pull/1778 makes Metrics Server more resilient to the root cause which should be fixed by [this](https://github.com/kubernetes/kubernetes/pull/137942) PR.