### PR TITLE
Skip Pod metrics if any container skipped

### DIFF
--- a/pkg/storage/pod.go
+++ b/pkg/storage/pod.go
@@ -72,7 +72,8 @@ func (s *podStorage) GetMetrics(pods ...*metav1.PartialObjectMetadata) ([]metric
 			usage, ti, err := resourceUsage(lastContainer, prevContainer)
 			if err != nil {
 				klog.ErrorS(err, "Skipping container usage metric", "container", container, "pod", klog.KRef(pod.Namespace, pod.Name))
-				continue
+				allContainersPresent = false
+				break
 			}
 			cms = append(cms, metrics.ContainerMetrics{
 				Name:  container,

--- a/pkg/storage/pod_test.go
+++ b/pkg/storage/pod_test.go
@@ -187,8 +187,7 @@ var _ = Describe("Pod storage", func() {
 		By("should get empty metrics when cpu metrics decrease")
 		ms, err := s.GetPodMetrics(&metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: podRef.Name, Namespace: podRef.Namespace}})
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ms).To(HaveLen(1))
-		Expect(ms[0].Containers).To(HaveLen(0))
+		Expect(ms).To(HaveLen(0))
 	})
 	It("should handle pod metrics older than prev", func() {
 		s := NewStorage(60 * time.Second)

--- a/pkg/storage/pod_test.go
+++ b/pkg/storage/pod_test.go
@@ -189,6 +189,28 @@ var _ = Describe("Pod storage", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ms).To(HaveLen(0))
 	})
+	It("should return pod empty metrics if decreased data point reported for one of many containers", func() {
+		s := NewStorage(60 * time.Second)
+		containerStart := time.Now()
+		podRef := apitypes.NamespacedName{Name: "pod1", Namespace: "ns1"}
+
+		By("storing previous metrics")
+		s.Store(podMetricsBatch(podMetrics(podRef,
+			containerMetricsPoint{"container1", newMetricsPoint(containerStart, containerStart.Add(110*time.Second), 20*CoreSecond, 4*MiByte)},
+			containerMetricsPoint{"container2", newMetricsPoint(containerStart, containerStart.Add(115*time.Second), 20*CoreSecond, 5*MiByte)},
+		)))
+
+		By("storing last metrics with CPU usage decreased for container2 only")
+		s.Store(podMetricsBatch(podMetrics(podRef,
+			containerMetricsPoint{"container1", newMetricsPoint(containerStart, containerStart.Add(120*time.Second), 30*CoreSecond, 4*MiByte)},
+			containerMetricsPoint{"container2", newMetricsPoint(containerStart, containerStart.Add(125*time.Second), 10*CoreSecond, 5*MiByte)},
+		)))
+
+		By("should get empty metrics when cpu metrics decrease for any container")
+		ms, err := s.GetPodMetrics(&metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: podRef.Name, Namespace: podRef.Namespace}})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ms).To(HaveLen(0))
+	})
 	It("should handle pod metrics older than prev", func() {
 		s := NewStorage(60 * time.Second)
 		containerStart := time.Now()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Currently, if a container's start time or CPU seconds decreases, we exclude that container's resource usage from the exposed metrics for its Pod: https://github.com/kubernetes-sigs/metrics-server/blob/78192ed59fca18aa82c64a206a47d97e9f078919/pkg/storage/types.go#L54-L59

In particular, if a Pod has multiple containers and one of the containers hits this condition, the Pod's metrics are still reported but with that container's contribution excluded. This can look like the Pod's utilisation is significantly lower than it actually is which can be especially problematic when using this information for horizontal or vertical scaling.

This PR changes this behaviour to exclude the entire Pod, favouring accurate metrics over unreliable/inconsistent metrics.