### PR TITLE
Fix golangci-lint fail and bump go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Update the base image in Makefile when updating golang version. This has to
 # be pre-pulled in order to work on GCB.
 ARG ARCH
-FROM golang:1.25.6 as build
+FROM golang:1.26.1 as build
 
 WORKDIR /go/src/sigs.k8s.io/metrics-server
 COPY go.mod .

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ ALL_BINARIES_PLATFORMS= $(addprefix linux/,$(ALL_ARCHITECTURES)) \
 
 # Tools versions
 # --------------
-GOLANGCI_VERSION:=2.6.2
+GOLANGCI_VERSION:=2.11.4
 
 # Tools CLI
 # ---------
@@ -81,7 +81,7 @@ CONTAINER_ARCH_TARGETS=$(addprefix container-,$(ALL_ARCHITECTURES))
 container:
 	# Pull base image explicitly. Keep in sync with Dockerfile, otherwise
 	# GCB builds will start failing.
-	${CONTAINER_CLI} pull golang:1.25.6
+	${CONTAINER_CLI} pull golang:1.26.1
 	${CONTAINER_CLI} build -t $(REGISTRY)/metrics-server-$(ARCH):$(CHECKSUM) --build-arg ARCH=$(ARCH) --build-arg GIT_TAG=$(GIT_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) .
 
 .PHONY: container-all

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/metrics-server
 
-go 1.25.6
+go 1.26.1
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
While reviewing PR #1783, I noticed that the verify target (and related CI/linting steps) still references an older version of golangci-lint.
This PR updates `golangci-lint` to the latest recommended version in the Makefile / CI configuration
At the same time, I am also bumping the Go version (in go.mod, Makefile, and Dockerfile).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

