### PR TITLE
bump golangci-lint to v2.11.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ ALL_BINARIES_PLATFORMS= $(addprefix linux/,$(ALL_ARCHITECTURES)) \
 
 # Tools versions
 # --------------
-GOLANGCI_VERSION:=2.6.2
+GOLANGCI_VERSION:=2.11.3
 
 # Tools CLI
 # ---------


### PR DESCRIPTION
**What this PR does / why we need it**:
After #1758 bumped `go.mod` to `go 1.25.6`, CI lint jobs started panicking:

`panic: file requires newer Go version go1.26 (application built with go1.25)`

Fix:
Bump `GOLANGCI_VERSION` from 2.6.2  to 2.11.3. The v2.11.3 release is compiled with go1.26.1 and correctly handles go 1.25.6 in  go.mod.

