### PR TITLE
Clear out service account token when using tls certs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,3 +58,27 @@ To start local development just run:
 kind create cluster
 skaffold dev -p test
 ```
+
+Or, to start one using client certificates, run:
+
+```sh
+kind create cluster
+mkdir -p _output/certs
+openssl req -new -newkey rsa:2048 -nodes -keyout _output/certs/client.key -out _output/certs/client.csr -subj "/CN=metrics-server-client"
+kubectl apply -f - <<EOF
+apiVersion: certificates.k8s.io/v1
+kind: CertificateSigningRequest
+metadata:
+  name: metrics-server-client
+spec:
+  request: $(cat _output/certs/client.csr | base64 | tr -d '\n')
+  signerName: kubernetes.io/kube-apiserver-client
+  expirationSeconds: 86400  # 24*60*60
+  usages:
+  - client auth
+EOF
+kubectl certificate approve metrics-server-client
+kubectl get csr metrics-server-client -o jsonpath='{.status.certificate}' | base64 -d > manifests/components/test-client-certs/client.crt
+cp _output/certs/client.key manifests/components/test-client-certs/client.key
+skaffold dev -p test-client-certs
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,11 +56,5 @@ To start local development just run:
 
 ```sh
 kind create cluster
-skaffold dev
-```
-
-To execute e2e tests run:
-
-```sh
-go test test/e2e_test.go -v -count=1
+skaffold dev -p test
 ```

--- a/cmd/metrics-server/app/options/kubelet_client.go
+++ b/cmd/metrics-server/app/options/kubelet_client.go
@@ -123,6 +123,8 @@ func (o KubeletClientOptions) Config(restConfig *rest.Config) *client.KubeletCli
 	if len(o.KubeletClientCertFile) > 0 {
 		config.Client.TLSClientConfig.CertFile = o.KubeletClientCertFile
 		config.Client.TLSClientConfig.CertData = nil
+		config.Client.BearerToken = ""
+		config.Client.BearerTokenFile = ""
 	}
 	if len(o.KubeletClientKeyFile) > 0 {
 		config.Client.TLSClientConfig.KeyFile = o.KubeletClientKeyFile

--- a/cmd/metrics-server/app/options/kubelet_client_test.go
+++ b/cmd/metrics-server/app/options/kubelet_client_test.go
@@ -113,7 +113,7 @@ func TestConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "KubeletClientCertFile overrides TLS client cert file",
+			name: "KubeletClientCertFile overrides TLS client cert file and removes bearer token to prevent leakage",
 			optionsFunc: func() *KubeletClientOptions {
 				o := NewKubeletClientOptions()
 				o.KubeletClientCertFile = "Override"
@@ -123,6 +123,8 @@ func TestConfig(t *testing.T) {
 				e := expected
 				e.Client.TLSClientConfig.CertFile = "Override"
 				e.Client.TLSClientConfig.CertData = nil
+				e.Client.BearerToken = ""
+				e.Client.BearerTokenFile = ""
 				return e
 			},
 		},

--- a/manifests/components/test-client-certs/.gitignore
+++ b/manifests/components/test-client-certs/.gitignore
@@ -1,0 +1,2 @@
+client.crt
+client.key

--- a/manifests/components/test-client-certs/kustomization.yaml
+++ b/manifests/components/test-client-certs/kustomization.yaml
@@ -1,0 +1,57 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+secretGenerator:
+- name: kubelet-client-certs
+  namespace: kube-system
+  files:
+  - client.crt=client.crt
+  - client.key=client.key
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: metrics-server
+    namespace: kube-system
+  patch: |
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --kubelet-insecure-tls
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --kubelet-client-certificate=/certs/client.crt
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --kubelet-client-key=/certs/client.key
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --v=4
+    - op: add
+      path: /spec/template/spec/containers/0/imagePullPolicy
+      value: Never
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --node-selector=metrics-server-skip!=true
+    - op: add
+      path: /spec/template/spec/volumes/-
+      value:
+        name: kubelet-client-certs
+        secret:
+          secretName: kubelet-client-certs
+    - op: add
+      path: /spec/template/spec/containers/0/volumeMounts/-
+      value:
+        name: kubelet-client-certs
+        mountPath: /certs
+- target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: ClusterRoleBinding
+    name: system:metrics-server
+  patch: |
+    - op: add
+      path: /subjects/-
+      value:
+        kind: User
+        name: metrics-server-client
+        apiGroup: rbac.authorization.k8s.io

--- a/manifests/overlays/test-client-certs/kustomization.yaml
+++ b/manifests/overlays/test-client-certs/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+components:
+- ../../components/test-client-certs

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -20,6 +20,11 @@ profiles:
       kustomize:
         paths:
           - manifests/overlays/test
+  - name: test-client-certs
+    deploy:
+      kustomize:
+        paths:
+          - manifests/overlays/test-client-certs
   - name: test-ha
     deploy:
       kustomize:

--- a/test/test-e2e.sh
+++ b/test/test-e2e.sh
@@ -96,6 +96,42 @@ create_cluster() {
   fi
 }
 
+provision_client_certificate() {
+  if [ "${SKAFFOLD_PROFILE}" = "test-client-certs" ]; then
+    echo "Provisioning client certificate via Kubernetes CSR API..."
+    mkdir -p _output/certs
+    openssl req -new -newkey rsa:2048 -nodes -keyout _output/certs/client.key -out _output/certs/client.csr -subj "/CN=metrics-server-client"
+
+    CSR_BASE64=$(cat _output/certs/client.csr | base64 | tr -d '\n')
+
+    cat <<EOF | ${KUBECTL} apply -f -
+apiVersion: certificates.k8s.io/v1
+kind: CertificateSigningRequest
+metadata:
+  name: metrics-server-client
+spec:
+  request: ${CSR_BASE64}
+  signerName: kubernetes.io/kube-apiserver-client
+  expirationSeconds: 86400  # 24*60*60
+  usages:
+  - client auth
+EOF
+
+    ${KUBECTL} certificate approve metrics-server-client
+
+    echo "Waiting for certificate to be issued..."
+    for i in $(seq 1 10); do
+      CERT=$(${KUBECTL} get csr metrics-server-client -o jsonpath='{.status.certificate}')
+      if [ -n "${CERT}" ]; then
+        echo "${CERT}" | base64 -d > manifests/components/test-client-certs/client.crt
+        break
+      fi
+      sleep 1
+    done
+    cp _output/certs/client.key manifests/components/test-client-certs/client.key
+  fi
+}
+
 deploy_metrics_server(){
   PATH="$PWD/_output:${PATH}" ${SKAFFOLD} run -p "${SKAFFOLD_PROFILE}"
   sleep 5
@@ -114,13 +150,14 @@ if [ "${SKAFFOLD_PROFILE}" = "helm" ] ; then
 fi
 setup_kind
 setup_skaffold
+setup_kubectl
 trap delete_cluster EXIT
 delete_cluster
 create_cluster
+provision_client_certificate
 deploy_metrics_server
 run_tests
 
 if [[ ${ARTIFACTS} != "" ]] ; then
-  setup_kubectl
   upload_metrics_server_logs
 fi


### PR DESCRIPTION
The service account token is unnecessary in this case and presents a
potential attack vector if a node in the cluster became compromised.

This PR also enables testing of the tls flow via a new skaffold target.

Internal tracking: b/511044406