### PR TITLE
feat(helm): add Helm OCI chart publishing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,23 @@ push-multi-arch:
 	@for arch in $(ALL_ARCHITECTURES); do ${CONTAINER_CLI} manifest annotate --arch $${arch} $(REGISTRY)/metrics-server:$(GIT_TAG) $(REGISTRY)/metrics-server-$${arch}:${GIT_TAG}; done
 	${CONTAINER_CLI} manifest push --purge $(REGISTRY)/metrics-server:$(GIT_TAG)
 
+# Helm chart rules
+# ----------------
+
+HELM?=helm
+HELM_CHART_DIR?=charts/metrics-server
+HELM_CHART_REPO?=$(REGISTRY)/charts
+
+.PHONY: package-helm
+package-helm:
+	mkdir -p $(OUTPUT_DIR)
+	$(HELM) package $(HELM_CHART_DIR) -d $(OUTPUT_DIR)
+
+.PHONY: push-helm
+push-helm: package-helm
+	chart_version=$$(grep -E '^version: ' $(HELM_CHART_DIR)/Chart.yaml | cut -d' ' -f2); \
+	$(HELM) push $(OUTPUT_DIR)/metrics-server-$${chart_version}.tgz oci://$(HELM_CHART_REPO)
+
 # Release rules
 # -------------
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,10 +8,28 @@ The Metrics Server is released on an as-needed basis. The process is as follows:
 1. An OWNER creates a draft GitHub release
 1. An OWNER creates an issue to release the corresponding Helm chart via the chart release process (below)
 1. An OWNER creates a release tag using `GIT_TAG=$VERSION make release-tag` and waits for [prow.k8s.io](prow.k8s.io) to build and push new images to [gcr.io/k8s-staging-metrics-server](https://gcr.io/k8s-staging-metrics-server)
-1. A PR in [kubernetes/k8s.io](https://github.com/kubernetes/k8s.io/blob/main/k8s.gcr.io/images/k8s-staging-metrics-server/images.yaml) is created to release images to `k8s.gcr.io`
+1. A PR in [kubernetes/k8s.io](https://github.com/kubernetes/k8s.io/blob/main/registry.k8s.io/images/k8s-staging-metrics-server/images.yaml) is created to release images and Helm OCI charts to `registry.k8s.io`
 1. An OWNER publishes the GitHub release. Once published, release manifests will be automatically added to the release by CI.
 1. An announcement email is sent to `kubernetes-sig-instrumentation@googlegroups.com` with the subject `[ANNOUNCE] metrics-server $VERSION is released`
 1. The release issue is closed
+
+## Helm OCI Chart Promotion
+
+Cloud Build publishes the Helm chart to `gcr.io/k8s-staging-metrics-server/charts/metrics-server:<chart-version>` on release tags.
+
+Promotion to `registry.k8s.io` uses the same `kubernetes/k8s.io` promotion flow as container images. After the chart is pushed to staging, add its digest and chart version to `registry.k8s.io/images/k8s-staging-metrics-server/images.yaml`:
+
+```yaml
+- name: charts/metrics-server
+  dmap:
+    "sha256:<digest>": ["<chart-version>"]
+```
+
+After the promotion PR merges, the chart is available at:
+
+```sh
+helm install metrics-server oci://registry.k8s.io/metrics-server/charts/metrics-server --version <chart-version>
+```
 
 ## Chart Release Process
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,3 +10,21 @@ steps:
     - GIT_COMMIT=$_PULL_BASE_SHA
     args:
     - push-all
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20231105-52c482caa0'
+    entrypoint: bash
+    env:
+    - HELM_CHART_REPO=gcr.io/k8s-staging-metrics-server/charts
+    args:
+    - -eu
+    - -c
+    - |
+      set -o pipefail
+
+      if [[ "$_PULL_BASE_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
+        echo "Detected SemVer tag ($_PULL_BASE_REF); pushing Helm chart."
+        curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+        gcloud auth configure-docker gcr.io --quiet
+        make push-helm
+      else
+        echo "Skipping Helm chart push: $_PULL_BASE_REF is not a SemVer tag."
+      fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This is yet another draft attempt to try to add Helm OCI chart publishing, resolving #1527. This is presented for discussion primarily. It's based on assessing [a variety of other K8s Helm OCI Chart implementations](https://github.com/kubernetes-sigs/metrics-server/issues/1527#issuecomment-4636897099).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1527.