### PR TITLE
fix: Require both node and pod metrics for storage readiness

### DIFF
--- a/pkg/scraper/scraper.go
+++ b/pkg/scraper/scraper.go
@@ -177,11 +177,6 @@ func (c *scraper) Scrape(baseCtx context.Context) *storage.MetricsBatch {
 	}
 
 	klog.V(1).InfoS("Scrape finished", "duration", myClock.Since(startTime), "nodeCount", len(res.Nodes), "podCount", len(res.Pods))
-	if len(res.Nodes) > 0 && len(res.Pods) == 0 {
-		klog.ErrorS(nil, "Scrape returned node metrics but no pod metrics, this may indicate a cAdvisor or kubelet issue", "nodeCount", len(res.Nodes))
-	} else if len(res.Pods) > 0 && len(res.Nodes) == 0 {
-		klog.ErrorS(nil, "Scrape returned pod metrics but no node metrics", "podCount", len(res.Pods))
-	}
 	return res
 }
 

--- a/pkg/scraper/scraper.go
+++ b/pkg/scraper/scraper.go
@@ -177,6 +177,11 @@ func (c *scraper) Scrape(baseCtx context.Context) *storage.MetricsBatch {
 	}
 
 	klog.V(1).InfoS("Scrape finished", "duration", myClock.Since(startTime), "nodeCount", len(res.Nodes), "podCount", len(res.Pods))
+	if len(res.Nodes) > 0 && len(res.Pods) == 0 {
+		klog.ErrorS(nil, "Scrape returned node metrics but no pod metrics, this may indicate a cAdvisor or kubelet issue", "nodeCount", len(res.Nodes))
+	} else if len(res.Pods) > 0 && len(res.Nodes) == 0 {
+		klog.ErrorS(nil, "Scrape returned pod metrics but no node metrics", "podCount", len(res.Pods))
+	}
 	return res
 }
 

--- a/pkg/storage/node_test.go
+++ b/pkg/storage/node_test.go
@@ -36,14 +36,14 @@ var _ = Describe("Node storage", func() {
 		s.Store(nodeMetricBatch(nodeMetricsPoint{"node1", newMetricsPoint(nodeStart, nodeStart.Add(10*time.Second), 10*CoreSecond, 2*MiByte)}))
 
 		By("waiting for second batch before becoming ready and serving metrics")
-		Expect(s.Ready()).NotTo(BeTrue())
+		Expect(s.NodeReady()).To(BeFalse())
 		checkNodeResponseEmpty(s, "node1")
 
 		By("storing second batch with node1 metrics")
 		s.Store(nodeMetricBatch(nodeMetricsPoint{"node1", newMetricsPoint(nodeStart, nodeStart.Add(20*time.Second), 20*CoreSecond, 3*MiByte)}))
 
 		By("becoming ready and returning metric for node1")
-		Expect(s.Ready()).To(BeTrue())
+		Expect(s.NodeReady()).To(BeTrue())
 		ms, err := s.GetNodeMetrics(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ms).To(HaveLen(1))
@@ -76,7 +76,7 @@ var _ = Describe("Node storage", func() {
 
 		By("should not be ready and return empty result for node1")
 		checkNodeResponseEmpty(s, "node1")
-		Expect(s.Ready()).NotTo(BeTrue())
+		Expect(s.NodeReady()).To(BeFalse())
 	})
 	It("exposes correct node metrics", func() {
 		pointsStored.Create(nil)
@@ -188,14 +188,14 @@ var _ = Describe("Node storage", func() {
 		s.Store(nodeMetricBatch(nodeMetricsPoint{"node1", newMetricsPoint(time.Time{}, nodeStart.Add(10*time.Second), 10*CoreSecond, 2*MiByte)}))
 
 		By("waiting for second batch before becoming ready and serving metrics")
-		Expect(s.Ready()).NotTo(BeTrue())
+		Expect(s.NodeReady()).To(BeFalse())
 		checkNodeResponseEmpty(s, "node1")
 
 		By("storing second batch with node1 metrics")
 		s.Store(nodeMetricBatch(nodeMetricsPoint{"node1", newMetricsPoint(time.Time{}, nodeStart.Add(20*time.Second), 20*CoreSecond, 3*MiByte)}))
 
 		By("becoming ready and returning metric for node1")
-		Expect(s.Ready()).To(BeTrue())
+		Expect(s.NodeReady()).To(BeTrue())
 		ms, err := s.GetNodeMetrics(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ms).Should(HaveLen(1))

--- a/pkg/storage/pod_test.go
+++ b/pkg/storage/pod_test.go
@@ -39,14 +39,14 @@ var _ = Describe("Pod storage", func() {
 		s.Store(podMetricsBatch(podMetrics(podRef, containerMetricsPoint{"container1", newMetricsPoint(containerStart, containerStart.Add(120*time.Second), 1*CoreSecond, 4*MiByte)})))
 
 		By("waiting for second batch before serving metrics")
-		Expect(s.Ready()).NotTo(BeTrue())
+		Expect(s.PodReady()).To(BeFalse())
 		checkPodResponseEmpty(s, podRef)
 
 		By("storing second batch with pod1 metrics")
 		s.Store(podMetricsBatch(podMetrics(podRef, containerMetricsPoint{"container1", newMetricsPoint(containerStart, containerStart.Add(125*time.Second), 6*CoreSecond, 5*MiByte)})))
 
-		By("returning metric for pod1")
-		Expect(s.Ready()).To(BeTrue())
+		By("becoming ready and returning metric for pod1")
+		Expect(s.PodReady()).To(BeTrue())
 		ms, err := s.GetPodMetrics(&metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: podRef.Name, Namespace: podRef.Namespace}})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ms).To(HaveLen(1))
@@ -86,8 +86,8 @@ var _ = Describe("Pod storage", func() {
 			containerMetricsPoint{"container2", newMetricsPoint(containerStart, containerStart.Add(125*time.Second), 7*CoreSecond, 7*MiByte)},
 		)))
 
-		By("returning correct metric values")
-		Expect(s.Ready()).To(BeTrue())
+		By("becoming ready and returning correct metric values")
+		Expect(s.PodReady()).To(BeTrue())
 		ms, err := s.GetPodMetrics(&metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: podRef.Name, Namespace: podRef.Namespace}})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ms).Should(HaveLen(1))
@@ -106,7 +106,7 @@ var _ = Describe("Pod storage", func() {
 		s.Store(batch)
 
 		By("return empty results for pod1")
-		Expect(s.Ready()).NotTo(BeTrue())
+		Expect(s.PodReady()).To(BeFalse())
 		checkPodResponseEmpty(s, podRef)
 	})
 	It("exposes correct pod metrics", func() {
@@ -242,7 +242,7 @@ var _ = Describe("Pod storage", func() {
 
 		By("storing first batch with pod1 metrics")
 		s.Store(podMetricsBatch(podMetrics(podRef, containerMetricsPoint{"container1", newMetricsPoint(containerStart, containerStart.Add(120*time.Second), 1*CoreSecond, 4*MiByte)})))
-		Expect(s.Ready()).NotTo(BeTrue())
+		Expect(s.PodReady()).To(BeFalse())
 		checkPodResponseEmpty(s, podRef)
 	})
 	It("should use start time to return metric in one cycle for fresh new container", func() {
@@ -252,7 +252,7 @@ var _ = Describe("Pod storage", func() {
 
 		By("storing first batch with pod1 metrics")
 		s.Store(podMetricsBatch(podMetrics(podRef, containerMetricsPoint{"container1", newMetricsPoint(containerStart, containerStart.Add(10*time.Second), 10*CoreSecond, 4*MiByte)})))
-		Expect(s.Ready()).To(BeTrue())
+		Expect(s.PodReady()).To(BeTrue())
 
 		ms, err := s.GetPodMetrics(&metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: podRef.Name, Namespace: podRef.Namespace}})
 		Expect(err).NotTo(HaveOccurred())
@@ -274,7 +274,7 @@ var _ = Describe("Pod storage", func() {
 
 		By("storing first batch with pod1 metrics")
 		s.Store(podMetricsBatch(podMetrics(podRef, containerMetricsPoint{"container1", newMetricsPoint(containerStart, containerStart.Add(-10*time.Second), 10*CoreSecond, 4*MiByte)})))
-		Expect(s.Ready()).NotTo(BeTrue())
+		Expect(s.PodReady()).To(BeFalse())
 		checkPodResponseEmpty(s, podRef)
 	})
 	It("should get empty metrics in one cycle for fresh new container's time duration less than 10s between start time and timestamp", func() {
@@ -284,7 +284,7 @@ var _ = Describe("Pod storage", func() {
 
 		By("storing first batch with pod1 metrics")
 		s.Store(podMetricsBatch(podMetrics(podRef, containerMetricsPoint{"container1", newMetricsPoint(containerStart, containerStart.Add(9*time.Second), 10*CoreSecond, 4*MiByte)})))
-		Expect(s.Ready()).NotTo(BeTrue())
+		Expect(s.PodReady()).To(BeFalse())
 		checkPodResponseEmpty(s, podRef)
 	})
 
@@ -297,14 +297,14 @@ var _ = Describe("Pod storage", func() {
 		s.Store(podMetricsBatch(podMetrics(podRef, containerMetricsPoint{"container1", newMetricsPoint(time.Time{}, containerStart.Add(120*time.Second), 1*CoreSecond, 4*MiByte)})))
 
 		By("waiting for second batch before serving metrics")
-		Expect(s.Ready()).NotTo(BeTrue())
+		Expect(s.PodReady()).To(BeFalse())
 		checkPodResponseEmpty(s, podRef)
 
 		By("storing second batch with pod1 metrics")
 		s.Store(podMetricsBatch(podMetrics(podRef, containerMetricsPoint{"container1", newMetricsPoint(time.Time{}, containerStart.Add(125*time.Second), 6*CoreSecond, 5*MiByte)})))
 
-		By("returning metric for pod1")
-		Expect(s.Ready()).To(BeTrue())
+		By("becoming ready and returning metric for pod1")
+		Expect(s.PodReady()).To(BeTrue())
 		ms, err := s.GetPodMetrics(&metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: podRef.Name, Namespace: podRef.Namespace}})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ms).To(HaveLen(1))

--- a/pkg/storage/ready_test.go
+++ b/pkg/storage/ready_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	apitypes "k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Storage readiness", func() {
+	It("is not ready when only node metrics are stored", func() {
+		s := NewStorage(60 * time.Second)
+		nodeStart := time.Now()
+
+		By("storing two node metric batches without any pod metrics")
+		s.Store(nodeMetricBatch(nodeMetricsPoint{"node1", newMetricsPoint(nodeStart, nodeStart.Add(10*time.Second), 10*CoreSecond, 2*MiByte)}))
+		Expect(s.Ready()).To(BeFalse())
+		s.Store(nodeMetricBatch(nodeMetricsPoint{"node1", newMetricsPoint(nodeStart, nodeStart.Add(20*time.Second), 20*CoreSecond, 3*MiByte)}))
+		Expect(s.Ready()).To(BeFalse())
+	})
+
+	It("is not ready when only pod metrics are stored", func() {
+		s := NewStorage(60 * time.Second)
+		containerStart := time.Now()
+		podRef := apitypes.NamespacedName{Name: "pod1", Namespace: "ns1"}
+
+		By("storing two pod metric batches without any node metrics")
+		s.Store(podMetricsBatch(podMetrics(podRef, containerMetricsPoint{"container1", newMetricsPoint(containerStart, containerStart.Add(120*time.Second), 1*CoreSecond, 4*MiByte)})))
+		Expect(s.Ready()).To(BeFalse())
+		s.Store(podMetricsBatch(podMetrics(podRef, containerMetricsPoint{"container1", newMetricsPoint(containerStart, containerStart.Add(125*time.Second), 6*CoreSecond, 5*MiByte)})))
+		Expect(s.Ready()).To(BeFalse())
+	})
+
+	It("is ready when both node and pod metrics are stored", func() {
+		s := NewStorage(60 * time.Second)
+		nodeStart := time.Now()
+		containerStart := nodeStart
+		podRef := apitypes.NamespacedName{Name: "pod1", Namespace: "ns1"}
+
+		By("storing first combined batch with both node and pod metrics")
+		s.Store(metricsBatch(
+			nodeMetricsPoint{"node1", newMetricsPoint(nodeStart, nodeStart.Add(10*time.Second), 10*CoreSecond, 2*MiByte)},
+			podMetrics(podRef, containerMetricsPoint{"container1", newMetricsPoint(containerStart, containerStart.Add(120*time.Second), 1*CoreSecond, 4*MiByte)}),
+		))
+		Expect(s.Ready()).To(BeFalse())
+
+		By("storing second combined batch")
+		s.Store(metricsBatch(
+			nodeMetricsPoint{"node1", newMetricsPoint(nodeStart, nodeStart.Add(20*time.Second), 20*CoreSecond, 3*MiByte)},
+			podMetrics(podRef, containerMetricsPoint{"container1", newMetricsPoint(containerStart, containerStart.Add(125*time.Second), 6*CoreSecond, 5*MiByte)}),
+		))
+		Expect(s.Ready()).To(BeTrue())
+	})
+})
+
+func metricsBatch(node nodeMetricsPoint, pod podMetricsPoint) *MetricsBatch {
+	return &MetricsBatch{
+		Nodes: map[string]MetricsPoint{node.Name: node.MetricsPoint},
+		Pods:  map[apitypes.NamespacedName]PodMetricsPoint{pod.NamespacedName: pod.PodMetricsPoint},
+	}
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -21,6 +21,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 	"k8s.io/metrics/pkg/apis/metrics"
 )
 
@@ -29,6 +30,9 @@ type storage struct {
 	mu    sync.RWMutex
 	pods  podStorage
 	nodes nodeStorage
+
+	prevNodesReady bool
+	prevPodsReady  bool
 }
 
 var _ Storage = (*storage)(nil)
@@ -38,11 +42,33 @@ func NewStorage(metricResolution time.Duration) *storage {
 }
 
 // Ready returns true if metrics-server's storage has accumulated enough metric
-// points to serve NodeMetrics.
+// points to serve both NodeMetrics and PodMetrics.
 func (s *storage) Ready() bool {
+	return s.NodeReady() && s.PodReady()
+}
+
+// NodeReady returns true if metrics-server's storage has accumulated enough
+// metric points to serve NodeMetrics.
+func (s *storage) NodeReady() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return len(s.nodes.prev) != 0 || len(s.pods.prev) != 0
+	return s.nodeReady()
+}
+
+// PodReady returns true if metrics-server's storage has accumulated enough
+// metric points to serve PodMetrics.
+func (s *storage) PodReady() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.podReady()
+}
+
+func (s *storage) nodeReady() bool {
+	return len(s.nodes.prev) != 0
+}
+
+func (s *storage) podReady() bool {
+	return len(s.pods.prev) != 0
 }
 
 func (s *storage) GetNodeMetrics(nodes ...*corev1.Node) ([]metrics.NodeMetrics, error) {
@@ -62,4 +88,28 @@ func (s *storage) Store(batch *MetricsBatch) {
 	defer s.mu.Unlock()
 	s.nodes.Store(batch)
 	s.pods.Store(batch)
+	s.logReadinessChange()
+}
+
+func (s *storage) logReadinessChange() {
+	nodesReady := s.nodeReady()
+	podsReady := s.podReady()
+
+	if nodesReady == s.prevNodesReady && podsReady == s.prevPodsReady {
+		return
+	}
+
+	switch {
+	case nodesReady && podsReady:
+		klog.V(2).InfoS("Metric storage is ready", "nodeMetrics", nodesReady, "podMetrics", podsReady)
+	case nodesReady && !podsReady:
+		klog.V(2).InfoS("Metric storage is not ready, pod metrics are missing, this may indicate a container-runtime or kubelet issue", "nodeMetrics", nodesReady, "podMetrics", podsReady)
+	case !nodesReady && podsReady:
+		klog.V(2).InfoS("Metric storage is not ready, node metrics are missing, this may indicate a kubelet issue", "nodeMetrics", nodesReady, "podMetrics", podsReady)
+	default:
+		klog.V(2).InfoS("Metric storage is not ready", "nodeMetrics", nodesReady, "podMetrics", podsReady)
+	}
+
+	s.prevNodesReady = nodesReady
+	s.prevPodsReady = podsReady
 }


### PR DESCRIPTION
Require both node and pod metrics for storage readiness

Storage.Ready() used || which allowed metrics-server to report
ready when only node metrics were present but no container metrics
were scraped. This caused kubectl top pods and HPA to silently
return empty results while the readiness probe passed.

Change || to && so that readiness requires both nodes.prev and
pods.prev to be populated, matching the original intent from
00a9be15.



<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #1816

