### PR TITLE
Fix cert-manager Issuer rendering annotations: null and wire documented Certificate annotations/labels

### DIFF
--- a/charts/metrics-server/CHANGELOG.md
+++ b/charts/metrics-server/CHANGELOG.md
@@ -16,11 +16,11 @@
 
 ### Changed
 
-- Apply `tls.certManager.annotations` and `tls.certManager.labels` to the cert-manager `Certificate` resource; these values are documented but were previously never rendered. _@yugstar_
+- Apply `tls.certManager.annotations` and `tls.certManager.labels` to the cert-manager `Certificate` resource; these values are documented but were previously never rendered. ([#1825](https://github.com/kubernetes-sigs/metrics-server/pull/1825)) _@yugstar_
 
 ### Fixed
 
-- Stop rendering `annotations: null` on the cert-manager `Issuer`, which referenced an undefined `additionalAnnotations` value. This mirrors the earlier APIService fix and prevents permanent GitOps `OutOfSync`. _@yugstar_
+- Stop rendering `annotations: null` on the cert-manager `Issuer`, which referenced an undefined `additionalAnnotations` value. This mirrors the earlier APIService fix and prevents permanent GitOps `OutOfSync`. ([#1825](https://github.com/kubernetes-sigs/metrics-server/pull/1825)) _@yugstar_
 
 ## [3.13.1] - 2026-02-27
 

--- a/charts/metrics-server/CHANGELOG.md
+++ b/charts/metrics-server/CHANGELOG.md
@@ -14,6 +14,14 @@
 
 ## [UNRELEASED]
 
+### Changed
+
+- Apply `tls.certManager.annotations` and `tls.certManager.labels` to the cert-manager `Certificate` resource; these values are documented but were previously never rendered. _@yugstar_
+
+### Fixed
+
+- Stop rendering `annotations: null` on the cert-manager `Issuer`, which referenced an undefined `additionalAnnotations` value. This mirrors the earlier APIService fix and prevents permanent GitOps `OutOfSync`. _@yugstar_
+
 ## [3.13.1] - 2026-02-27
 
 ### Changed

--- a/charts/metrics-server/templates/certificate.yaml
+++ b/charts/metrics-server/templates/certificate.yaml
@@ -3,8 +3,6 @@
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
   name: {{ include "metrics-server.fullname" . }}-issuer
   namespace: {{ .Release.Namespace }}
 spec:
@@ -14,6 +12,14 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  {{- with .Values.tls.certManager.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.tls.certManager.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ include "metrics-server.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:


### PR DESCRIPTION
## Summary

Two related fixes in `charts/metrics-server/templates/certificate.yaml` (only triggered when `tls.type=cert-manager`):

### 1. Issuer renders `annotations: null` (bug)
The `Issuer` metadata referenced `.Values.additionalAnnotations`, which **does not exist** anywhere in `values.yaml`. So `helm template --set tls.type=cert-manager` rendered:

```yaml
kind: Issuer
metadata:
  annotations:
    null
```

This is the same `annotations: null` → GitOps `OutOfSync` footgun that was already fixed for the **APIService** template in #1752. I removed the broken block (the value never existed, so there is no behavior to preserve).

### 2. `tls.certManager.annotations` / `tls.certManager.labels` were dead values
`values.yaml` declares `tls.certManager.annotations` and `tls.certManager.labels`, and the README documents them as *"Add extra annotations/labels to the Certificate resource"* — but they were **never wired** to the `Certificate`. This applies them (guarded with `with`), so the documented values actually take effect.

## Verification

- `helm template --set tls.type=cert-manager` → Issuer no longer renders `annotations: null` (no stray `null` anywhere).
- `--set tls.certManager.annotations.foo=bar --set tls.certManager.labels.team=infra` → both now appear on the `Certificate`.
- Default render otherwise unchanged; `helm lint` passes.
- Per `CONTRIBUTING.md`, `Chart.yaml` is intentionally left unmodified; the change is recorded under `CHANGELOG.md` `[UNRELEASED]`.
