### PR TITLE
Pin base images by digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Update the base image in Makefile when updating golang version. This has to
 # be pre-pulled in order to work on GCB.
 ARG ARCH
-FROM golang:1.26.4 as build
+FROM golang:1.26.4@sha256:f96cc555eb8db430159a3aa6797cd5bae561945b7b0fe7d0e284c63a3b291609 as build
 
 WORKDIR /go/src/sigs.k8s.io/metrics-server
 COPY go.mod .
@@ -17,7 +17,7 @@ ARG GIT_COMMIT
 ARG GIT_TAG
 RUN make metrics-server
 
-FROM gcr.io/distroless/static:latest-$ARCH
+FROM --platform=linux/${ARCH} gcr.io/distroless/static@sha256:d5f030ca7c5793784e9ea4178a116da360250411d13921a5af27c6cb5a5949bf
 COPY --from=build /go/src/sigs.k8s.io/metrics-server/metrics-server /
 USER 65534
 ENTRYPOINT ["/metrics-server"]

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ CONTAINER_ARCH_TARGETS=$(addprefix container-,$(ALL_ARCHITECTURES))
 container:
 	# Pull base image explicitly. Keep in sync with Dockerfile, otherwise
 	# GCB builds will start failing.
-	${CONTAINER_CLI} pull golang:1.26.4
+	${CONTAINER_CLI} pull golang:1.26.4@sha256:f96cc555eb8db430159a3aa6797cd5bae561945b7b0fe7d0e284c63a3b291609
 	${CONTAINER_CLI} build -t $(REGISTRY)/metrics-server-$(ARCH):$(CHECKSUM) --build-arg ARCH=$(ARCH) --build-arg GIT_TAG=$(GIT_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) .
 
 .PHONY: container-all


### PR DESCRIPTION
## Summary

- Pin the Go build image to the digest for golang:1.26.4.
- Pin the distroless static runtime image to its multi-architecture index digest.
- Select the runtime platform from ARCH so cross-architecture image builds retain their correct metadata.
- Keep the GCB base-image pre-pull in Makefile synchronized with the Dockerfile.

## Why

Mutable image tags make builds non-reproducible. A digest fixes the exact base-image content used by each build.

## Validation

- make test-image
- make container ARCH=arm64
- Verified the resulting images report amd64/linux and arm64/linux respectively.

Fixes #1836