### PR TITLE
Remove undocumented custom GOMAXPROCS env

### DIFF
--- a/cmd/metrics-server/metrics-server.go
+++ b/cmd/metrics-server/metrics-server.go
@@ -15,9 +15,6 @@
 package main
 
 import (
-	"os"
-	"runtime"
-
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/component-base/logs"
 

--- a/cmd/metrics-server/metrics-server.go
+++ b/cmd/metrics-server/metrics-server.go
@@ -28,10 +28,6 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	if len(os.Getenv("GOMAXPROCS")) == 0 {
-		runtime.GOMAXPROCS(runtime.NumCPU())
-	}
-
 	cmd := app.NewMetricsServerCommand(genericapiserver.SetupSignalHandler())
 	if err := cmd.Execute(); err != nil {
 		panic(err)


### PR DESCRIPTION
**What this PR does / why we need it**:

The code quietly slipped in when repo was re-organized for standard layout. Until Go 1.25 is shadowed the default runtime behavior. Since 1.25 if suppresses the container aware default behaviour.
