### PR TITLE
fix(scraper): prune per-node kubelet metrics for removed nodes

### DIFF
--- a/pkg/scraper/scraper.go
+++ b/pkg/scraper/scraper.go
@@ -101,6 +101,7 @@ type scraper struct {
 	kubeletClient client.KubeletMetricsGetter
 	scrapeTimeout time.Duration
 	labelSelector labels.Selector
+	knownNodes    map[string]struct{}
 }
 
 var _ Scraper = (*scraper)(nil)
@@ -117,6 +118,8 @@ func (c *scraper) Scrape(baseCtx context.Context) *storage.MetricsBatch {
 	if err != nil {
 		// report the error and continue on in case of partial results
 		klog.ErrorS(err, "Failed to list nodes")
+	} else {
+		c.pruneStaleNodeMetrics(nodes)
 	}
 	klog.V(1).InfoS("Scraping metrics from nodes", "nodes", klog.KObjSlice(nodes), "nodeCount", len(nodes), "nodeSelector", c.labelSelector)
 
@@ -181,6 +184,23 @@ func (c *scraper) Scrape(baseCtx context.Context) *storage.MetricsBatch {
 
 	klog.V(1).InfoS("Scrape finished", "duration", myClock.Since(startTime), "nodeCount", len(res.Nodes), "podCount", len(res.Pods))
 	return res
+}
+
+func (c *scraper) pruneStaleNodeMetrics(nodes []*corev1.Node) {
+	current := make(map[string]struct{}, len(nodes))
+	for _, node := range nodes {
+		current[node.Name] = struct{}{}
+	}
+
+	for nodeName := range c.knownNodes {
+		if _, ok := current[nodeName]; ok {
+			continue
+		}
+		requestDuration.Delete(map[string]string{"node": nodeName})
+		lastRequestTime.DeleteLabelValues(nodeName)
+	}
+
+	c.knownNodes = current
 }
 
 func (c *scraper) collectNode(ctx context.Context, node *corev1.Node) (*storage.MetricsBatch, error) {

--- a/pkg/scraper/scraper_test.go
+++ b/pkg/scraper/scraper_test.go
@@ -226,6 +226,78 @@ var _ = Describe("Scraper", func() {
 		By("running the scraper")
 		scraper.Scrape(context.Background())
 	})
+
+	It("should remove per-node metrics when nodes leave the cluster", func() {
+		requestDuration.Create(nil)
+		lastRequestTime.Create(nil)
+		requestDuration.Reset()
+		lastRequestTime.Reset()
+
+		myClock = mockClock{
+			now:   time.Time{},
+			later: time.Time{}.Add(time.Second),
+		}
+		nodes := fakeNodeLister{nodes: []*corev1.Node{node1}}
+		scraper := NewScraper(&nodes, &client, 3*time.Second, labelRequirement)
+
+		By("scraping a single node")
+		scraper.Scrape(context.Background())
+
+		err := testutil.CollectAndCompare(lastRequestTime, strings.NewReader(`
+		# HELP metrics_server_kubelet_last_request_time_seconds [ALPHA] Time of last request performed to Kubelet API since unix epoch in seconds
+		# TYPE metrics_server_kubelet_last_request_time_seconds gauge
+		metrics_server_kubelet_last_request_time_seconds{node="node1"} -6.21355968e+10
+		`), "metrics_server_kubelet_last_request_time_seconds")
+		Expect(err).NotTo(HaveOccurred())
+
+		By("removing the node from the cluster")
+		nodes.nodes = []*corev1.Node{}
+
+		By("scraping again")
+		scraper.Scrape(context.Background())
+
+		err = testutil.CollectAndCompare(lastRequestTime, strings.NewReader(`
+		# HELP metrics_server_kubelet_last_request_time_seconds [ALPHA] Time of last request performed to Kubelet API since unix epoch in seconds
+		# TYPE metrics_server_kubelet_last_request_time_seconds gauge
+		`), "metrics_server_kubelet_last_request_time_seconds")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = testutil.CollectAndCompare(requestDuration, strings.NewReader(`
+		# HELP metrics_server_kubelet_request_duration_seconds [ALPHA] Duration of requests to Kubelet API in seconds
+		# TYPE metrics_server_kubelet_request_duration_seconds histogram
+		`), "metrics_server_kubelet_request_duration_seconds")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should not remove per-node metrics when listing nodes fails", func() {
+		requestDuration.Create(nil)
+		lastRequestTime.Create(nil)
+		requestDuration.Reset()
+		lastRequestTime.Reset()
+
+		myClock = mockClock{
+			now:   time.Time{},
+			later: time.Time{}.Add(time.Second),
+		}
+		nodes := fakeNodeLister{nodes: []*corev1.Node{node1}}
+		scraper := NewScraper(&nodes, &client, 3*time.Second, labelRequirement)
+
+		By("scraping a single node")
+		scraper.Scrape(context.Background())
+
+		By("failing the next node list")
+		nodes.listErr = fmt.Errorf("something went wrong, expectedly")
+
+		By("scraping again")
+		scraper.Scrape(context.Background())
+
+		err := testutil.CollectAndCompare(lastRequestTime, strings.NewReader(`
+		# HELP metrics_server_kubelet_last_request_time_seconds [ALPHA] Time of last request performed to Kubelet API since unix epoch in seconds
+		# TYPE metrics_server_kubelet_last_request_time_seconds gauge
+		metrics_server_kubelet_last_request_time_seconds{node="node1"} -6.21355968e+10
+		`), "metrics_server_kubelet_last_request_time_seconds")
+		Expect(err).NotTo(HaveOccurred())
+	})
 })
 
 func metricPoint(cpu, memory uint64, time time.Time) storage.MetricsPoint {


### PR DESCRIPTION
Delete stale label values for `metrics_server_kubelet_request_duration_second`s and `metrics_server_kubelet_last_request_time_seconds` after a successful node list when nodes are no longer in the cluster.

Skip pruning when node listing fails to avoid wiping metrics during transient API errors.

Related-to: kubernetes-sigs/metrics-server#1876

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

